### PR TITLE
Expose `functions_without_tree_logic`

### DIFF
--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -169,7 +169,7 @@ def _create_combined_function_from_dag(
         targets,
     )
 
-    _arglist = _create_arguments_of_concatenated_function(_functions, dag)
+    _arglist = create_arguments_of_concatenated_function(_functions, dag)
     _exec_info = _create_execution_info(_functions, dag)
     _concatenated = _create_concatenated_function(
         _exec_info,
@@ -333,12 +333,12 @@ def _create_complete_dag(
 
     """
     functions_arguments_dict = {
-        name: _get_free_arguments(function) for name, function in functions.items()
+        name: get_free_arguments(function) for name, function in functions.items()
     }
     return nx.DiGraph(functions_arguments_dict).reverse()  # type: ignore[arg-type]
 
 
-def _get_free_arguments(
+def get_free_arguments(
     func: GenericCallable,
 ) -> list[str]:
     arguments = list(inspect.signature(func).parameters)
@@ -379,7 +379,7 @@ def _limit_dag_to_targets_and_their_ancestors(
     return dag
 
 
-def _create_arguments_of_concatenated_function(
+def create_arguments_of_concatenated_function(
     functions: dict[str, GenericCallable],
     dag: nx.DiGraph[str],
 ) -> list[str]:
@@ -418,7 +418,7 @@ def _create_execution_info(
     out = {}
     for node in nx.topological_sort(dag):
         if node in functions:
-            arguments = _get_free_arguments(functions[node])
+            arguments = get_free_arguments(functions[node])
             out[node] = FunctionExecutionInfo(func=functions[node], arguments=arguments)
     return out
 

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -4,7 +4,7 @@ from dags.tree.dag_tree import (
     concatenate_functions_tree,
     create_dag_tree,
     create_input_structure_tree,
-    functions_for_dags_concatenate_functions,
+    functions_without_tree_logic,
 )
 from dags.tree.tree_utils import (
     QUAL_NAME_DELIMITER,
@@ -28,7 +28,7 @@ __all__ = [
     "create_input_structure_tree",
     "create_dag_tree",
     "concatenate_functions_tree",
-    "functions_for_dags_concatenate_functions",
+    "functions_without_tree_logic",
     # Validation functions
     "fail_if_path_elements_have_trailing_undersores",
     "fail_if_top_level_elements_repeated_in_paths",

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -4,6 +4,7 @@ from dags.tree.dag_tree import (
     concatenate_functions_tree,
     create_dag_tree,
     create_input_structure_tree,
+    functions_for_dags_concatenate_functions,
 )
 from dags.tree.tree_utils import (
     QUAL_NAME_DELIMITER,
@@ -27,6 +28,7 @@ __all__ = [
     "create_input_structure_tree",
     "create_dag_tree",
     "concatenate_functions_tree",
+    "functions_for_dags_concatenate_functions",
     # Validation functions
     "fail_if_path_elements_have_trailing_undersores",
     "fail_if_top_level_elements_repeated_in_paths",

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -96,7 +96,7 @@ def create_input_structure_tree(
     if targets is None:
         return nested_input_structure
 
-    functions_for_flat_dags = functions_for_dags_concatenate_functions(
+    functions_for_flat_dags = functions_without_tree_logic(
         functions=functions,
         input_structure=nested_input_structure,
         top_level_namespace=top_level_namespace,
@@ -134,7 +134,7 @@ def create_dag_tree(
         functions=functions,
         input_structure=input_structure,
     )
-    functions_for_flat_dags = functions_for_dags_concatenate_functions(
+    functions_for_flat_dags = functions_without_tree_logic(
         functions=functions,
         input_structure=input_structure,
         top_level_namespace=top_level_namespace,
@@ -169,7 +169,7 @@ def concatenate_functions_tree(
         functions=functions,
         input_structure=input_structure,
     )
-    functions_for_flat_dags = functions_for_dags_concatenate_functions(
+    functions_for_flat_dags = functions_without_tree_logic(
         functions=functions,
         input_structure=input_structure,
         top_level_namespace=top_level_namespace,
@@ -193,32 +193,7 @@ def concatenate_functions_tree(
     return wrapper
 
 
-def _get_top_level_namespace_initial(
-    tree_paths: set[tuple[str, ...]],
-    top_level_inputs: set[str],
-) -> set[str]:
-    """Get the namespace of the top level.
-
-    Args:
-        tree_paths: The set of tree paths.
-        top_level_inputs: A set of input names in the top-level namespace.
-
-    Returns
-    -------
-        The elements of the top-level namespace.
-    """
-    top_level_elements_from_functions = {path[0] for path in tree_paths}
-    return top_level_elements_from_functions | top_level_inputs
-
-
-def _get_top_level_namespace_final(
-    functions: NestedFunctionDict, input_structure: NestedInputStructureDict
-) -> set[str]:
-    all_tree_paths = set(tree_paths(functions)) | set(tree_paths(input_structure))
-    return {path[0] for path in all_tree_paths}
-
-
-def functions_for_dags_concatenate_functions(
+def functions_without_tree_logic(
     functions: NestedFunctionDict,
     input_structure: NestedInputStructureDict,
     top_level_namespace: set[str],
@@ -269,6 +244,31 @@ def functions_for_dags_concatenate_functions(
         qual_name_functions[qual_name_from_tree_path(path)] = renamed
 
     return qual_name_functions
+
+
+def _get_top_level_namespace_initial(
+    tree_paths: set[tuple[str, ...]],
+    top_level_inputs: set[str],
+) -> set[str]:
+    """Get the namespace of the top level.
+
+    Args:
+        tree_paths: The set of tree paths.
+        top_level_inputs: A set of input names in the top-level namespace.
+
+    Returns
+    -------
+        The elements of the top-level namespace.
+    """
+    top_level_elements_from_functions = {path[0] for path in tree_paths}
+    return top_level_elements_from_functions | top_level_inputs
+
+
+def _get_top_level_namespace_final(
+    functions: NestedFunctionDict, input_structure: NestedInputStructureDict
+) -> set[str]:
+    all_tree_paths = set(tree_paths(functions)) | set(tree_paths(input_structure))
+    return {path[0] for path in all_tree_paths}
 
 
 def _get_parameter_rel_to_abs_mapper(

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -96,20 +96,18 @@ def create_input_structure_tree(
     if targets is None:
         return nested_input_structure
 
-    qual_name_functions = functions_for_dags_concatenate_functions(
+    functions_for_flat_dags = functions_for_dags_concatenate_functions(
         functions=functions,
         input_structure=nested_input_structure,
         top_level_namespace=top_level_namespace,
         perform_checks=False,
     )
-    dag_tree = create_dag_tree(
-        functions=functions,
-        targets=targets,
-        input_structure=nested_input_structure,
-        perform_checks=False,
-    )
     parameters = dag.create_arguments_of_concatenated_function(
-        functions=qual_name_functions, dag=dag_tree
+        functions=functions_for_flat_dags,
+        dag=dag.create_dag(
+            functions=functions_for_flat_dags,
+            targets=qual_names(targets),
+        ),
     )
     return unflatten_from_qual_names(dict.fromkeys(parameters))
 
@@ -136,15 +134,15 @@ def create_dag_tree(
         functions=functions,
         input_structure=input_structure,
     )
-    qual_name_functions = functions_for_dags_concatenate_functions(
+    functions_for_flat_dags = functions_for_dags_concatenate_functions(
         functions=functions,
         input_structure=input_structure,
         top_level_namespace=top_level_namespace,
         perform_checks=perform_checks,
     )
-    qual_name_targets = qual_names(targets) if targets is not None else None
+    targets_for_flat_dags = qual_names(targets) if targets is not None else None
 
-    return dag.create_dag(qual_name_functions, qual_name_targets)
+    return dag.create_dag(functions_for_flat_dags, targets_for_flat_dags)
 
 
 def concatenate_functions_tree(
@@ -171,18 +169,17 @@ def concatenate_functions_tree(
         functions=functions,
         input_structure=input_structure,
     )
-    qual_name_targets = qual_names(targets) if targets is not None else None
-
-    qual_name_functions = functions_for_dags_concatenate_functions(
+    functions_for_flat_dags = functions_for_dags_concatenate_functions(
         functions=functions,
         input_structure=input_structure,
         top_level_namespace=top_level_namespace,
         perform_checks=perform_checks,
     )
+    targets_for_flat_dags = qual_names(targets) if targets is not None else None
 
     concatenated_function = dag.concatenate_functions(
-        qual_name_functions,
-        qual_name_targets,
+        functions=functions_for_flat_dags,
+        targets=targets_for_flat_dags,
         return_type="dict",
         enforce_signature=enforce_signature,
     )

--- a/tests/test_dag_tree/test_parameters.py
+++ b/tests/test_dag_tree/test_parameters.py
@@ -12,7 +12,7 @@ from dags.tree.dag_tree import (
     _get_parameter_tree_path,
     _get_top_level_namespace_final,
     _get_top_level_namespace_initial,
-    _qual_name_functions_with_abs_path_args,
+    functions_for_dags_concatenate_functions,
 )
 
 if TYPE_CHECKING:
@@ -197,7 +197,7 @@ def test_correct_argument_names(
         input_structure=input_structure,
     )
 
-    qual_name_functions = _qual_name_functions_with_abs_path_args(
+    qual_name_functions = functions_for_dags_concatenate_functions(
         functions=functions,
         input_structure=input_structure,
         top_level_namespace=top_level_namespace,

--- a/tests/test_dag_tree/test_parameters.py
+++ b/tests/test_dag_tree/test_parameters.py
@@ -12,7 +12,7 @@ from dags.tree.dag_tree import (
     _get_parameter_tree_path,
     _get_top_level_namespace_final,
     _get_top_level_namespace_initial,
-    functions_for_dags_concatenate_functions,
+    functions_without_tree_logic,
 )
 
 if TYPE_CHECKING:
@@ -197,7 +197,7 @@ def test_correct_argument_names(
         input_structure=input_structure,
     )
 
-    qual_name_functions = functions_for_dags_concatenate_functions(
+    qual_name_functions = functions_without_tree_logic(
         functions=functions,
         input_structure=input_structure,
         top_level_namespace=top_level_namespace,


### PR DESCRIPTION
We [realised in GETTSIM](https://github.com/iza-institute-of-labor-economics/gettsim/issues/848) that it will often be helpful to work with an object that removes all tree logic, i.e. a dictionary with the following properties
1. Keys are qualified absolute names
2. Functions in the values only take qualified absolute names as a inputs

Previously, the function `_qual_name_functions_with_abs_path_args` created precisely this object. This PR renames it to `functions_without_tree_logic` and exposes it.