### PR TITLE
Rename function and change interface.

### DIFF
--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -4,7 +4,7 @@ from dags.tree.dag_tree import (
     concatenate_functions_tree,
     create_dag_tree,
     create_input_structure_tree,
-    functions_without_tree_logic,
+    expand_arguments_to_qualified_names,
     one_function_without_tree_logic,
 )
 from dags.tree.tree_utils import (
@@ -30,7 +30,7 @@ __all__ = [
     "create_input_structure_tree",
     "create_dag_tree",
     "concatenate_functions_tree",
-    "functions_without_tree_logic",
+    "expand_arguments_to_qualified_names",
     "one_function_without_tree_logic",
     # Validation functions
     "fail_if_paths_are_invalid",

--- a/src/dags/tree/validation.py
+++ b/src/dags/tree/validation.py
@@ -37,7 +37,7 @@ def fail_if_paths_are_invalid(
 
     Note: Sometimes you want to pass both `functions` (the nested function dict you will
     start out with) and `qual_abs_names_functions` (the result of running
-    `functions_without_tree_logic` on `functions`, which contains the converted
+    `expand_arguments_to_qualified_names` on `functions`, which contains the converted
     parameters of functions, too). Even though the former may be seen as a subset of the
     latter, the conversion to qualified absolute names is not innocuous when it comes to
     the check for trailing underscores. The reason is that the conversion from qualified
@@ -48,7 +48,7 @@ def fail_if_paths_are_invalid(
         functions:
             The nested function dict.
         qual_abs_names_functions:
-            The result of running `functions_without_tree_logic` on `functions`.
+            The result of running `expand_arguments_to_qualified_names` on `functions`.
         data_tree:
             The tree of input data (typically not used together with `input_structure`).
         input_structure:

--- a/tests/test_dag_tree/test_parameters.py
+++ b/tests/test_dag_tree/test_parameters.py
@@ -12,8 +12,9 @@ from dags.tree.dag_tree import (
     _get_top_level_namespace_final,
     _get_top_level_namespace_initial,
     _map_parameters_rel_to_abs,
-    functions_without_tree_logic,
+    expand_arguments_to_qualified_names,
 )
+from dags.tree.tree_utils import flatten_to_qual_names
 
 if TYPE_CHECKING:
     from dags.tree.typing import (
@@ -195,8 +196,8 @@ def test_correct_argument_names(
         functions=functions,
         inputs=input_structure,
     )
-    qual_name_functions = functions_without_tree_logic(
-        functions=functions,
+    qual_name_functions = expand_arguments_to_qualified_names(
+        functions=flatten_to_qual_names(functions),
         top_level_namespace=top_level_namespace,
     )
     assert (


### PR DESCRIPTION
The function `dags.tree.functions_without_tree_logic` was a bit confusing because
1. it accepted a pytree and returned a flat dictionary with qualified names as keys.
2. what it really did was to change the arguments of the functions so that all names are qualified

This PR changes it so that it accepts a flat dictionary with qualified names as keys, too. It also changes the name to `expand_arguments_to_qualified_names`.