### PR TITLE
Validate consistency of type annotations during function-creation time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           - py313
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.4
+      - uses: prefix-dev/setup-pixi@v0.8.8
         with:
           pixi-version: v0.42.1
           cache: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,11 @@ repos:
       - id: check-ast
       - id: check-docstring-first
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.0
+    rev: v1.37.1
     hooks:
       - id: yamllint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.8
     hooks:
       # Run the linter.
       - id: ruff

--- a/pixi.lock
+++ b/pixi.lock
@@ -4637,8 +4637,8 @@ packages:
   timestamp: 1736761414276
 - pypi: .
   name: dags
-  version: 0.2.4.dev22+g75a6612.d20250324
-  sha256: 94f3133bb62a44d7d560f3c6a16ab90a37131fb07a449458b3d11f9656d2f579
+  version: 0.3.1.dev8+gf92b174.d20250506
+  sha256: 77b4280d6e1d82d2335e7748892fe0c08d8952cb6a7bf6bfcb0e5cbbf3932cbf
   requires_dist:
   - flatten-dict
   - networkx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ extend-ignore = [
 "docs/source/conf.py" = ["INP001", "ERA001", "RUF100"]
 "src/dags/tree/__init__.py" = ["RUF022"]
 "tests/*" = ["D401", "FBT001", "INP001", "PLC2401"]
+"tests/test_dag.py" = ["ARG001"]
 
 
 [tool.ruff.lint.pydocstyle]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -497,7 +497,9 @@ def _create_concatenated_function(
         return_annotation = inspect.Parameter.empty
 
     @with_signature(
-        args=args, enforce=enforce_signature, return_annotation=return_annotation
+        args=args,
+        enforce=enforce_signature,
+        return_annotation=return_annotation,  # type: ignore[arg-type]
     )
     def concatenated(*args: Any, **kwargs: Any) -> tuple[Any, ...]:  # noqa: ANN401
         results = {**dict(zip(arglist, args, strict=False)), **kwargs}

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -478,7 +478,7 @@ def _create_concatenated_function(
     return_annotation: type | tuple[type, ...]
 
     if set_annotations:
-        args, return_annotation = _get_annotations_from_execution_list(
+        args, return_annotation = _get_annotations_from_execution_info(
             execution_info,
             arglist=arglist,
             targets=targets,
@@ -527,7 +527,7 @@ def _get_annotations_from_func(
     return argument_types, signature.return_annotation
 
 
-def _get_annotations_from_execution_list(
+def _get_annotations_from_execution_info(
     execution_info: dict[str, FunctionExecutionInfo],
     arglist: list[str],
     targets: list[str],
@@ -583,12 +583,7 @@ def _get_annotations_from_execution_list(
                     f"{current_type.__name__}', but {explanation}"
                 )
 
-        new_argument_types = {
-            arg: info.argument_annotations[arg]
-            for arg in info.arguments
-            if arg not in types
-        }
-        types.update(new_argument_types)
+        types.update(info.argument_annotations)
 
     args = {k: v for k, v in types.items() if k in arglist}
     return_annotation = tuple[tuple(types[target] for target in targets)]  # type: ignore[misc,valid-type]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -31,14 +31,23 @@ class FunctionExecutionInfo:
     Attributes
     ----------
         func: The function to execute.
+        argument_annotations: The argument annotations of the function.
+        return_annotation: The return annotation of the function.
+
+    Properties
+    ----------
         arguments: The names of the arguments of the function.
 
     """
 
     func: GenericCallable
-    arguments: list[str]
     argument_annotations: dict[str, type]
     return_annotation: type
+
+    @property
+    def arguments(self) -> list[str]:
+        """The names of the arguments of the function."""
+        return list(self.argument_annotations)
 
 
 def concatenate_functions(
@@ -440,7 +449,6 @@ def _create_execution_info(
 
             out[node] = FunctionExecutionInfo(
                 func=functions[node],
-                arguments=arguments,
                 argument_annotations=argument_annotations,
                 return_annotation=return_annotation,
             )
@@ -559,7 +567,7 @@ def _get_annotations_from_execution_info(
         # before appearing as a function itself.
         types[name] = info.return_annotation
 
-        for arg in set(info.arguments).intersection(types.keys()):
+        for arg in set(info.argument_annotations).intersection(types.keys()):
             # Verify that the type information on arg that was retrieved up to this
             # point (earlier_type) is consistent with the type information on arg from
             # the current function info (current_type).

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -539,16 +539,11 @@ def _get_annotations(
     """
     types_dict: dict[str, type] = {}
     for name, info in execution_info.items():
-        if name in types_dict:
-            exp_type = types_dict[name]
-            got_type = info.return_type
-            if exp_type != got_type:
-                raise AnnotationMismatchError(
-                    f"function {name} has return type {exp_type.__name__}, but type "
-                    f"annotation '{name}: {got_type.__name__}' is used elsewhere."
-                )
-        else:
-            types_dict[name] = info.return_type
+        # We do not need to check whether name is already in types_dict, because the
+        # functions in execution_info are topologically sorted, and hence, it is
+        # impossible for a function to appear as a dependency of another function
+        # before appearing as a function itself.
+        types_dict[name] = info.return_type
 
         for arg in set(info.arguments).intersection(types_dict.keys()):
             exp_type = types_dict[arg]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -550,7 +550,7 @@ def _get_annotations(
         else:
             types_dict[name] = info.return_type
 
-        for arg in info.arguments & types_dict.keys():
+        for arg in set(info.arguments).intersection(types_dict.keys()):
             exp_type = types_dict[arg]
             got_type = info.argument_types[arg]
             if exp_type != got_type:

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -4,7 +4,6 @@ import functools
 import inspect
 import textwrap
 from dataclasses import dataclass
-from types import GenericAlias
 from typing import TYPE_CHECKING, Any, cast
 
 import networkx as nx
@@ -38,8 +37,8 @@ class FunctionExecutionInfo:
 
     func: GenericCallable
     arguments: list[str]
-    argument_types: dict[str, GenericAlias]
-    return_type: GenericAlias
+    argument_types: dict[str, type]
+    return_type: type
 
 
 def concatenate_functions(
@@ -452,12 +451,12 @@ def _create_execution_info(
 def _get_argument_types(
     func: GenericCallable,
     free_arguments: list[str],
-) -> dict[str, GenericAlias]:
+) -> dict[str, type]:
     parameters = inspect.signature(func).parameters
     return {arg: parameters[arg].annotation for arg in free_arguments}
 
 
-def _get_return_type(func: GenericCallable) -> GenericAlias:
+def _get_return_type(func: GenericCallable) -> type:
     return inspect.signature(func).return_annotation
 
 
@@ -488,8 +487,8 @@ def _create_concatenated_function(
         The concatenated function
 
     """
-    args: list[str] | dict[str, GenericAlias]
-    return_annotation: GenericAlias | tuple[GenericAlias, ...]
+    args: list[str] | dict[str, type]
+    return_annotation: type | tuple[type, ...]
 
     if set_annotations:
         args, return_annotation = _get_annotations(execution_info, arglist, targets)
@@ -516,7 +515,7 @@ def _get_annotations(
     execution_info: dict[str, FunctionExecutionInfo],
     arglist: list[str],
     targets: list[str],
-) -> tuple[dict[str, GenericAlias], tuple[GenericAlias, ...]]:
+) -> tuple[dict[str, type], tuple[type, ...]]:
     """Get the (argument and return) annotations of the concatenated function.
 
     Args:
@@ -536,7 +535,7 @@ def _get_annotations(
             the functions are not consistent.
 
     """
-    types_dict: dict[str, GenericAlias] = {}
+    types_dict: dict[str, type] = {}
     for name, info in execution_info.items():
         if name in types_dict:
             exp_type = types_dict[name]

--- a/src/dags/exceptions.py
+++ b/src/dags/exceptions.py
@@ -1,0 +1,2 @@
+class AnnotationMismatchError(TypeError):
+    """Raised when function annotations are incompatible during concatenation."""

--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -4,15 +4,13 @@ import operator
 from collections.abc import Callable
 from typing import TypedDict, get_args, overload
 
-from typing_extensions import TypeVarTuple, Unpack
+from typing_extensions import Unpack
 
-from dags.typing import P, T
-
-Ts = TypeVarTuple("Ts")
+from dags.typing import HetTupleType, P, T
 
 
 def single_output(
-    func: Callable[P, tuple[T, Unpack[Ts]]] | Callable[P, tuple[T, ...]],
+    func: Callable[P, tuple[T, Unpack[HetTupleType]]] | Callable[P, tuple[T, ...]],
 ) -> Callable[P, T]:
     """Convert tuple output to single output; i.e. the first element of the tuple."""
 

--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -4,10 +4,16 @@ import operator
 from collections.abc import Callable
 from typing import get_args, overload
 
+from typing_extensions import TypeVarTuple, Unpack
+
 from dags.typing import P, T
 
+Ts = TypeVarTuple("Ts")
 
-def single_output(func: Callable[P, tuple[T, ...]]) -> Callable[P, T]:
+
+def single_output(
+    func: Callable[P, tuple[T, Unpack[Ts]]] | Callable[P, tuple[T, ...]],
+) -> Callable[P, T]:
     """Convert tuple output to single output; i.e. the first element of the tuple."""
 
     @functools.wraps(func)

--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 import operator
 from collections.abc import Callable
-from typing import get_args, overload
+from typing import TypedDict, get_args, overload
 
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -63,10 +63,12 @@ def dict_output(
 
         signature = inspect.signature(func)
         if signature.return_annotation is not inspect.Parameter.empty:
-            element_type = _union_from_types_tuple(
-                get_args(signature.return_annotation)
-            )
-            signature = signature.replace(return_annotation=dict[str, element_type])  # type: ignore[valid-type]
+            element_types = get_args(signature.return_annotation)
+            td_name = f"{func.__name__.title()}Return"
+            annotations = dict(zip(keys, element_types, strict=True))
+            return_annotation = TypedDict(td_name, annotations)  # type: ignore[misc]
+            signature = signature.replace(return_annotation=return_annotation)
+
         wrapper_dict_output.__signature__ = signature  # type: ignore[attr-defined]
 
         return wrapper_dict_output

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -1,16 +1,15 @@
 import functools
 import inspect
 from collections.abc import Callable
-from types import GenericAlias
 from typing import Any, cast, overload
 
 from dags.typing import P, R
 
 
 def create_signature(
-    args: dict[str, GenericAlias] | list[str] | None = None,
-    kwargs: dict[str, GenericAlias] | list[str] | None = None,
-    return_annotation: GenericAlias = inspect.Parameter.empty,
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> inspect.Signature:
     """Create a inspect.Signature object based on args and kwargs.
 
@@ -55,30 +54,30 @@ def create_signature(
 def with_signature(
     func: Callable[P, R],
     *,
-    args: dict[str, GenericAlias] | list[str] | None = None,
-    kwargs: dict[str, GenericAlias] | list[str] | None = None,
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: GenericAlias = inspect.Parameter.empty,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> Callable[P, R]: ...
 
 
 @overload
 def with_signature(
     *,
-    args: dict[str, GenericAlias] | list[str] | None = None,
-    kwargs: dict[str, GenericAlias] | list[str] | None = None,
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: GenericAlias = inspect.Parameter.empty,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def with_signature(
     func: Callable[P, R] | None = None,
     *,
-    args: dict[str, GenericAlias] | list[str] | None = None,
-    kwargs: dict[str, GenericAlias] | list[str] | None = None,
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: GenericAlias = inspect.Parameter.empty,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Add a signature to a function of type `f(*args, **kwargs)` (decorator).
 
@@ -241,8 +240,8 @@ def rename_arguments(
 
 
 def _convert_to_type_dict(
-    arg: dict[str, GenericAlias] | list[str] | None,
-) -> dict[str, GenericAlias]:
+    arg: dict[str, type] | list[str] | None,
+) -> dict[str, type]:
     if arg is None:
         return {}
     if isinstance(arg, list):

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -7,65 +7,77 @@ from dags.typing import P, R
 
 
 def create_signature(
-    args: list[str] | None = None, kwargs: list[str] | None = None
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> inspect.Signature:
     """Create a inspect.Signature object based on args and kwargs.
 
     Args:
-        args: The names of positional or keyword arguments.
-        kwargs: The keyword only arguments.
+        args: If a list, the names of positional or keyword arguments. If a dict,
+            the names of positional or keyword arguments and their types.
+        kwargs: If a list, the names of keyword only arguments. If a dict,
+            the names of keyword only arguments and their types.
+        return_annotation: The return annotation.
 
     Returns
     -------
         The signature
 
     """
-    _args = [] if args is None else args
-    _kwargs = [] if kwargs is None else kwargs
+    _args = _convert_to_type_dict(args)
+    _kwargs = _convert_to_type_dict(kwargs)
 
     parameter_objects = []
-    for arg in _args:
+    for arg, arg_type in _args.items():
         param = inspect.Parameter(
             name=arg,
             kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=arg_type,
         )
         parameter_objects.append(param)
 
-    for kwarg in _kwargs:
+    for kwarg, kwarg_type in _kwargs.items():
         param = inspect.Parameter(
             name=kwarg,
             kind=inspect.Parameter.KEYWORD_ONLY,
+            annotation=kwarg_type,
         )
         parameter_objects.append(param)
 
-    return inspect.Signature(parameters=parameter_objects)
+    return inspect.Signature(
+        parameters=parameter_objects, return_annotation=return_annotation
+    )
 
 
 @overload
 def with_signature(
     func: Callable[P, R],
     *,
-    args: list[str] | None = None,
-    kwargs: list[str] | None = None,
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
     enforce: bool = True,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> Callable[P, R]: ...
 
 
 @overload
 def with_signature(
     *,
-    args: list[str] | None = None,
-    kwargs: list[str] | None = None,
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
     enforce: bool = True,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def with_signature(
     func: Callable[P, R] | None = None,
     *,
-    args: list[str] | None = None,
-    kwargs: list[str] | None = None,
+    args: dict[str, type] | list[str] | None = None,
+    kwargs: dict[str, type] | list[str] | None = None,
     enforce: bool = True,
+    return_annotation: type = inspect.Parameter.empty,
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Add a signature to a function of type `f(*args, **kwargs)` (decorator).
 
@@ -75,11 +87,14 @@ def with_signature(
     Args:
         func: The function to be decorated. Should take `*args`
             and `**kwargs` as only arguments.
-        args: The names of positional or keyword arguments.
-        kwargs: The keyword only arguments.
+        args: If a list, the names of positional or keyword arguments. If a dict,
+            the names of positional or keyword arguments and their types.
+        kwargs: If a list, the names of keyword only arguments. If a dict,
+            the names of keyword only arguments and their types.
         enforce: Whether the signature should be enforced or just
             added to the function for introspection. This creates runtime
             overhead.
+        return_annotation: The return annotation.
 
     Returns
     -------
@@ -87,17 +102,19 @@ def with_signature(
     """
 
     def decorator_with_signature(func: Callable[P, R]) -> Callable[P, R]:
-        _args: list[str] = [] if args is None else args
-        _kwargs: list[str] = [] if kwargs is None else kwargs
-        signature = create_signature(_args, _kwargs)
+        _args = _convert_to_type_dict(args)
+        _kwargs = _convert_to_type_dict(kwargs)
+        signature = create_signature(
+            _args, _kwargs, return_annotation=return_annotation
+        )
         valid_kwargs: set[str] = set(_kwargs) | set(_args)
         funcname: str = getattr(func, "__name__", "function")
 
         @functools.wraps(func)
         def wrapper_with_signature(*args: P.args, **kwargs: P.kwargs) -> R:
             if enforce:
-                _fail_if_too_many_positional_arguments(args, _args, funcname)
-                present_args: set[str] = set(_args[: len(args)])
+                _fail_if_too_many_positional_arguments(args, list(_args), funcname)
+                present_args: set[str] = set(list(_args)[: len(args)])
                 present_kwargs: set[str] = set(kwargs)
                 _fail_if_duplicated_arguments(present_args, present_kwargs, funcname)
                 _fail_if_invalid_keyword_arguments(
@@ -176,9 +193,8 @@ def rename_arguments(
     """
 
     def decorator_rename_arguments(func: Callable[P, R]) -> Callable[P, R]:
-        old_parameters: dict[str, inspect.Parameter] = dict(
-            inspect.signature(func).parameters
-        )
+        old_signature = inspect.signature(func)
+        old_parameters: dict[str, inspect.Parameter] = dict(old_signature.parameters)
         parameters: list[inspect.Parameter] = []
         # mapper is assumed not to be None when renaming is desired.
         for name, param in old_parameters.items():
@@ -187,7 +203,9 @@ def rename_arguments(
             else:
                 parameters.append(param)
 
-        signature = inspect.Signature(parameters=parameters)
+        signature = inspect.Signature(
+            parameters=parameters, return_annotation=old_signature.return_annotation
+        )
 
         reverse_mapper: dict[str, str] = (
             {v: k for k, v in mapper.items()} if mapper is not None else {}
@@ -219,3 +237,13 @@ def rename_arguments(
     if func is not None:
         return decorator_rename_arguments(func)
     return decorator_rename_arguments
+
+
+def _convert_to_type_dict(arg: dict[str, type] | list[str] | None) -> dict[str, type]:
+    if arg is None:
+        return {}
+    if isinstance(arg, list):
+        return dict.fromkeys(arg, inspect.Parameter.empty)
+    if isinstance(arg, dict):
+        return arg
+    raise ValueError(f"Invalid type for arg: {type(arg)}")

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -25,8 +25,8 @@ def create_signature(
         The signature
 
     """
-    _args = _convert_to_type_dict(args)
-    _kwargs = _convert_to_type_dict(kwargs)
+    _args = _map_names_to_types(args)
+    _kwargs = _map_names_to_types(kwargs)
 
     parameter_objects = []
     for arg, arg_type in _args.items():
@@ -102,8 +102,8 @@ def with_signature(
     """
 
     def decorator_with_signature(func: Callable[P, R]) -> Callable[P, R]:
-        _args = _convert_to_type_dict(args)
-        _kwargs = _convert_to_type_dict(kwargs)
+        _args = _map_names_to_types(args)
+        _kwargs = _map_names_to_types(kwargs)
         signature = create_signature(
             _args, _kwargs, return_annotation=return_annotation
         )
@@ -239,7 +239,7 @@ def rename_arguments(
     return decorator_rename_arguments
 
 
-def _convert_to_type_dict(
+def _map_names_to_types(
     arg: dict[str, type] | list[str] | None,
 ) -> dict[str, type]:
     if arg is None:

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -1,15 +1,16 @@
 import functools
 import inspect
 from collections.abc import Callable
+from types import GenericAlias
 from typing import Any, cast, overload
 
 from dags.typing import P, R
 
 
 def create_signature(
-    args: dict[str, type] | list[str] | None = None,
-    kwargs: dict[str, type] | list[str] | None = None,
-    return_annotation: type = inspect.Parameter.empty,
+    args: dict[str, GenericAlias] | list[str] | None = None,
+    kwargs: dict[str, GenericAlias] | list[str] | None = None,
+    return_annotation: GenericAlias = inspect.Parameter.empty,
 ) -> inspect.Signature:
     """Create a inspect.Signature object based on args and kwargs.
 
@@ -54,30 +55,30 @@ def create_signature(
 def with_signature(
     func: Callable[P, R],
     *,
-    args: dict[str, type] | list[str] | None = None,
-    kwargs: dict[str, type] | list[str] | None = None,
+    args: dict[str, GenericAlias] | list[str] | None = None,
+    kwargs: dict[str, GenericAlias] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: type = inspect.Parameter.empty,
+    return_annotation: GenericAlias = inspect.Parameter.empty,
 ) -> Callable[P, R]: ...
 
 
 @overload
 def with_signature(
     *,
-    args: dict[str, type] | list[str] | None = None,
-    kwargs: dict[str, type] | list[str] | None = None,
+    args: dict[str, GenericAlias] | list[str] | None = None,
+    kwargs: dict[str, GenericAlias] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: type = inspect.Parameter.empty,
+    return_annotation: GenericAlias = inspect.Parameter.empty,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
 def with_signature(
     func: Callable[P, R] | None = None,
     *,
-    args: dict[str, type] | list[str] | None = None,
-    kwargs: dict[str, type] | list[str] | None = None,
+    args: dict[str, GenericAlias] | list[str] | None = None,
+    kwargs: dict[str, GenericAlias] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: type = inspect.Parameter.empty,
+    return_annotation: GenericAlias = inspect.Parameter.empty,
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Add a signature to a function of type `f(*args, **kwargs)` (decorator).
 
@@ -239,7 +240,9 @@ def rename_arguments(
     return decorator_rename_arguments
 
 
-def _convert_to_type_dict(arg: dict[str, type] | list[str] | None) -> dict[str, type]:
+def _convert_to_type_dict(
+    arg: dict[str, GenericAlias] | list[str] | None,
+) -> dict[str, GenericAlias]:
     if arg is None:
         return {}
     if isinstance(arg, list):

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -25,11 +25,8 @@ def create_signature(
         The signature
 
     """
-    _args = _map_names_to_types(args)
-    _kwargs = _map_names_to_types(kwargs)
-
     parameter_objects = []
-    for arg, arg_type in _args.items():
+    for arg, arg_type in _map_names_to_types(args).items():
         param = inspect.Parameter(
             name=arg,
             kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
@@ -37,7 +34,7 @@ def create_signature(
         )
         parameter_objects.append(param)
 
-    for kwarg, kwarg_type in _kwargs.items():
+    for kwarg, kwarg_type in _map_names_to_types(kwargs).items():
         param = inspect.Parameter(
             name=kwarg,
             kind=inspect.Parameter.KEYWORD_ONLY,

--- a/src/dags/typing.py
+++ b/src/dags/typing.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Literal, ParamSpec, TypeVar
+from typing import Any, Literal, ParamSpec, TypeVar, TypeVarTuple
 
 GenericCallable = Callable[..., Any]
 FunctionCollection = dict[str, GenericCallable] | list[GenericCallable]
@@ -7,7 +7,12 @@ TargetType = str | list[str] | None
 CombinedFunctionReturnType = Literal["tuple", "list", "dict"]
 
 
-# P captures the parameter types, R captures the return type
+# ParamSpec representing the full signature (positional and keyword parameters) of a
+# callable
 P = ParamSpec("P")
+# TypeVar representing the return type of a callable
 R = TypeVar("R")
+# Generic type variable for use in type constructors
 T = TypeVar("T")
+# Variadic TypeVar for tuples of arbitrary length with heterogeneous element types
+HetTupleType = TypeVarTuple("HetTupleType")

--- a/src/dags/typing.py
+++ b/src/dags/typing.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
-from typing import Any, Literal, ParamSpec, TypeVar, TypeVarTuple
+from typing import Any, Literal, ParamSpec, TypeVar
+
+from typing_extensions import TypeVarTuple
 
 GenericCallable = Callable[..., Any]
 FunctionCollection = dict[str, GenericCallable] | list[GenericCallable]

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,42 @@
+import pytest
+
+from dags.dag import concatenate_functions
+from dags.exceptions import AnnotationMismatchError
+
+
+def test_argument_annotations_mismatch() -> None:
+    """Problem: f expects a: int, but g expects a: float."""
+
+    def f(a: int) -> int:
+        return a
+
+    def g(a: float) -> int:
+        return int(a)
+
+    with pytest.raises(
+        AnnotationMismatchError,
+        match=(
+            "function g has the argument type annotation 'a: float', but "
+            "type annotation 'a: int' is used elsewhere."
+        ),
+    ):
+        concatenate_functions([f, g], set_annotations=True)
+
+
+def test_argument_annoations_mismatch_with_return_annotation() -> None:
+    """Problem: f expects g: int, but g() returns float."""
+
+    def f(g: int) -> int:
+        return g
+
+    def g() -> float:
+        return 1.0
+
+    with pytest.raises(
+        AnnotationMismatchError,
+        match=(
+            "function f has the argument type annotation 'g: int', but function g has "
+            "return type: float."
+        ),
+    ):
+        concatenate_functions([f, g], set_annotations=True)

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -68,12 +68,12 @@ def test_concatenate_functions_no_target() -> None:
 
     assert calculated_args == expected_args
 
-    def expected(
-        working_hours: int,  # noqa: ARG001
-        wage: float,  # noqa: ARG001
-        leisure_weight: float,  # noqa: ARG001
+    def expected(  # type: ignore[empty-body]
+        working_hours: int,
+        wage: float,
+        leisure_weight: float,
     ) -> tuple[float, int, float]:
-        return (1.0, 1, 1.0)
+        pass
 
     assert inspect.signature(concatenated) == inspect.signature(expected)
 
@@ -95,12 +95,8 @@ def test_concatenate_functions_single_target() -> None:
 
     assert calculated_args == expected_args
 
-    def expected(
-        working_hours: int,  # noqa: ARG001
-        wage: float,  # noqa: ARG001
-        leisure_weight: float,  # noqa: ARG001
-    ) -> float:
-        return 1.0
+    def expected(working_hours: int, wage: float, leisure_weight: float) -> float:  # type: ignore[empty-body]
+        pass
 
     assert inspect.signature(concatenated) == inspect.signature(expected)
 
@@ -118,40 +114,27 @@ def test_concatenate_functions_multi_target(
 
     calculated_result = concatenated(wage=5, working_hours=8, leisure_weight=2)
 
-    expected_result = {
+    _expected_result = {
         "_utility": _complete_utility(wage=5, working_hours=8, leisure_weight=2),
         "_consumption": _consumption(wage=5, working_hours=8),
     }
+
+    return_annotation: type[object]
+    expected_result: tuple[float, ...] | list[float] | dict[str, float]
     if return_type == "tuple":
-
-        def expected(
-            working_hours: int,  # noqa: ARG001
-            wage: float,  # noqa: ARG001
-            leisure_weight: float,  # noqa: ARG001
-        ) -> tuple[float, float]:
-            return (1.0, 1.0)
-
-        expected_result = tuple(expected_result.values())
+        return_annotation = tuple[float, float]
+        expected_result = tuple(_expected_result.values())
     elif return_type == "list":
-
-        def expected(
-            working_hours: int,  # noqa: ARG001
-            wage: float,  # noqa: ARG001
-            leisure_weight: float,  # noqa: ARG001
-        ) -> list[float]:
-            return [1.0, 1.0]
-
-        expected_result = list(expected_result.values())
+        return_annotation = list[float]
+        expected_result = list(_expected_result.values())
     elif return_type == "dict":
+        return_annotation = dict[str, float]
+        expected_result = dict(_expected_result)
 
-        def expected(
-            working_hours: int,  # noqa: ARG001
-            wage: float,  # noqa: ARG001
-            leisure_weight: float,  # noqa: ARG001
-        ) -> dict[str, float]:
-            return {"_utility": 1.0, "_consumption": 1.0}
-
-        expected_result = dict(expected_result)
+    def expected(
+        working_hours: int, wage: float, leisure_weight: float
+    ) -> return_annotation:  # type: ignore[valid-type]
+        pass
 
     assert calculated_result == expected_result
     assert inspect.signature(concatenated) == inspect.signature(expected)
@@ -224,7 +207,7 @@ def test_partialled_argument_is_ignored() -> None:
     def expected(c: bool, d: int) -> float:
         return 1 + 2 + float(c) + d
 
-    assert concatenated(3, 4) == expected(c=3, d=4)
+    assert concatenated(c=True, d=4) == expected(c=True, d=4)
     assert inspect.signature(concatenated) == inspect.signature(expected)
 
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -5,6 +5,7 @@ from typing import TypedDict, get_type_hints
 import pytest
 
 from dags.dag import (
+    _get_annotations_from_func,
     concatenate_functions,
     create_dag,
     get_ancestors,
@@ -270,3 +271,12 @@ def test_fail_if_cycle_in_dag(funcs: FunctionCollection) -> None:
             functions=funcs,
             targets=["_utility"],
         )
+
+
+def test_get_annotations_from_func() -> None:
+    def f(a: int, b: float, c: bool) -> float:
+        return 1.0
+
+    got = _get_annotations_from_func(f, free_arguments=["a", "b"])
+    exp = {"a": int, "b": float}, float
+    assert got == exp

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -51,7 +51,7 @@ def test_aggregated_output_decorator() -> None:
 
 
 def test_single_output_direct_call() -> None:
-    def f():
+    def f() -> tuple[int, ...]:
         return (1,)
 
     g = single_output(f)

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -1,4 +1,5 @@
 import inspect
+from typing import TypedDict, get_type_hints
 
 from dags.output import aggregated_output, dict_output, list_output, single_output
 
@@ -10,10 +11,10 @@ def test_single_output_decorator() -> None:
 
     assert f() == 1
 
-    def expected_signature() -> int:
+    def expected() -> int:
         return 1
 
-    assert inspect.signature(f) == inspect.signature(expected_signature)
+    assert inspect.signature(f) == inspect.signature(expected)
 
 
 def test_dict_output_decorator() -> None:
@@ -23,10 +24,26 @@ def test_dict_output_decorator() -> None:
 
     assert f() == {"a": 1, "b": 2.0}
 
-    def expected_signature() -> dict[str, int | float]:
+    class FReturn(TypedDict):
+        a: int
+        b: float
+
+    def expected() -> FReturn:
         return {"a": 1, "b": 2.0}
 
-    assert inspect.signature(f) == inspect.signature(expected_signature)
+    got_signature = inspect.signature(f)
+    expected_signature = inspect.signature(expected)
+
+    assert got_signature.parameters == expected_signature.parameters
+    # In the "dict" case, the return annotation is a TypedDict. This cannot be compared
+    # using ==, so we compare the name and implied dictionary of type hints.
+    assert (
+        got_signature.return_annotation.__name__
+        == expected_signature.return_annotation.__name__
+    )
+    assert get_type_hints(got_signature.return_annotation) == get_type_hints(
+        expected_signature.return_annotation
+    )
 
 
 def test_list_output_decorator() -> None:
@@ -36,10 +53,10 @@ def test_list_output_decorator() -> None:
 
     assert f() == [1, 2.0]
 
-    def expected_signature() -> list[int | float]:
+    def expected() -> list[int | float]:
         return [1, 2.0]
 
-    assert inspect.signature(f) == inspect.signature(expected_signature)
+    assert inspect.signature(f) == inspect.signature(expected)
 
 
 def test_aggregated_output_decorator() -> None:

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -1,7 +1,13 @@
 import inspect
 from typing import TypedDict, get_type_hints
 
-from dags.output import aggregated_output, dict_output, list_output, single_output
+from dags.output import (
+    _union_from_types_tuple,
+    aggregated_output,
+    dict_output,
+    list_output,
+    single_output,
+)
 
 
 def test_single_output_decorator() -> None:
@@ -100,3 +106,7 @@ def test_aggregated_output_direct_call() -> None:
 
     g = aggregated_output(f, aggregator=lambda x, y: x + y)
     assert g() == 3
+
+
+def test_union_from_types_tuple() -> None:
+    assert _union_from_types_tuple((int, float)) == int | float

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -1,28 +1,45 @@
+import inspect
+
 from dags.output import aggregated_output, dict_output, list_output, single_output
 
 
 def test_single_output_decorator() -> None:
     @single_output
-    def f():
+    def f() -> tuple[int, ...]:
         return (1,)
 
     assert f() == 1
 
+    def expected_signature() -> int:
+        return 1
+
+    assert inspect.signature(f) == inspect.signature(expected_signature)
+
 
 def test_dict_output_decorator() -> None:
     @dict_output(keys=["a", "b"])
-    def f():
-        return (1, 2)
+    def f() -> tuple[int, float]:
+        return (1, 2.0)
 
-    assert f() == {"a": 1, "b": 2}
+    assert f() == {"a": 1, "b": 2.0}
+
+    def expected_signature() -> dict[str, int | float]:
+        return {"a": 1, "b": 2.0}
+
+    assert inspect.signature(f) == inspect.signature(expected_signature)
 
 
 def test_list_output_decorator() -> None:
     @list_output
-    def f():
-        return (1, 2)
+    def f() -> tuple[int, float]:
+        return (1, 2.0)
 
-    assert f() == [1, 2]
+    assert f() == [1, 2.0]
+
+    def expected_signature() -> list[int | float]:
+        return [1, 2.0]
+
+    assert inspect.signature(f) == inspect.signature(expected_signature)
 
 
 def test_aggregated_output_decorator() -> None:


### PR DESCRIPTION
In this PR, we

1. Add the possibility to validate the consistency of type annotations of functions inside the dag (at function-creation time)
2. Create type annotations of the concatenated function and add these to the signature

> [!NOTE]
> Point (2) allows us to validate the input types during function-execution time, which we will do in a separate PR.

### Added behavior

The following now works:

```python
def f(g: int) -> float:
   return float(g)
   
def g(a: int) -> int:
   return a
   
concatenated = dags.concatenate_functions([f, g], set_annotations=True)
```

where `concatenated` will then have the same signature as

```python
def concatenated(a: int) -> tuple[float, int]:
   _g = g(a)
   return f(_g), _g
```

In the case of `return_type = "dict"`, the return type of the concatenated function becomes a `TypedDict`.

In all cases the user can infer type annotations via `inspect.signature(concatenated)`, and, depending on the requested `return_type`, also information on the return annotation (see discussion below).

### Discussion

The static typing of decorators in `output.py` is not perfect. The main problem is that the concatenated function returns a tuple that can have heterogeneous type information. This concatenated function is then passed through the output functions:

- `single_output`: This is properly typed, and we can communicate, even statically, that we only care about the first entry of the tuple of annotations
- `list_output`: Here we cannot do much and need to create a union type
- `dict_output`: In this case, we dynamically create a `TypedDict` instance that contains the type annotation information. This does *not* render nicely when checking via `concatenated?`; however, it allows to get the dictionary mapping output names to their types using `typing.get_type_hints(inspect.signature(concatenated).return_annotation)`, from which one could (dynamically) build a dataclass.
- `aggregated_output`: In this case, we cannot do anything, as far as I can tell, since we cannot assume how the aggregation strategy transforms the types.