### PR TITLE
Implement `get_input_types` function

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -258,11 +258,10 @@ Utilizing type annotations
 --------------------------
 
 If your functions have type annotations, dags can use this information to infer the
-types of the inputs and outputs of the combined function. To activate this feature, you
-can set the ``set_annotations`` parameter to ``True`` when calling
-``concatenate_functions``.
+types of the inputs and outputs of the combined function. To activate this feature, set
+the ``set_annotations`` parameter to ``True`` when calling ``concatenate_functions``.
 
-Let's look at the first example again, but this time with type annotations:
+Let's return to the first example and add type annotations:
 
 
 .. code-block:: python
@@ -300,9 +299,21 @@ We can inspect the signature of the combined function to see the type annotation
 .. note::
 
     If the type annotations are not consistent across the functions, dags will raise an
-    error. In the above example, this could happen if the type hint for argument ``y``
-    in function ``f`` would be different from the type hint for argument ``y`` in
-    function ``g``.
+    error. In the above example, if instead of ``g(y: int, z: int)`` we had written:
+
+    .. code-block:: python
+
+        def g(y: bool, z: int) -> int:
+            return 0.5 * y * z
+
+
+    the result would have been:
+
+    .. code-block:: pytb
+
+        dags.exceptions.AnnotationMismatchError:
+        function g has the argument type annotation 'y: bool',
+        but type annotation 'y: int' is used elsewhere.
 
 In many cases, it is useful to get the type annotations of the input arguments of the
 combined function in form of a dictionary. This can be achieved easily using the

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -252,3 +252,69 @@ We can simply rename the arguments programmatically:
 .. code-block:: python
 
     0.6
+
+
+Utilizing type annotations
+--------------------------
+
+If your functions have type annotations, dags can use this information to infer the
+types of the inputs and outputs of the combined function. To activate this feature, you
+can set the ``set_annotations`` parameter to ``True`` when calling
+``concatenate_functions``.
+
+Let's look at the first example again, but this time with type annotations:
+
+
+.. code-block:: python
+
+    def f(x: float, y: int) -> float:
+        return x**2 + y**2
+
+
+    def g(y: int, z: int) -> int:
+        return 0.5 * y * z
+
+
+    def h(f: float, g: int) -> float:
+        return g / f
+
+    combined = concatenate_functions(
+        [f, g, h],
+        targets="h",
+        set_annotations=True,
+    )
+
+
+We can inspect the signature of the combined function to see the type annotations:
+
+.. code-block:: python
+
+    import inspect
+    inspect.signature(combined)
+
+
+.. code-block:: python
+
+    <Signature (x: float, y: int, z: int) -> float>
+
+.. note::
+
+    If the type annotations are not consistent across the functions, dags will raise an
+    error. In the above example, this could happen if the type hint for argument ``y``
+    in function ``f`` would be different from the type hint for argument ``y`` in
+    function ``g``.
+
+In many cases, it is useful to get the type annotations of the input arguments of the
+combined function in form of a dictionary. This can be achieved easily using the
+``get_input_types`` function:
+
+.. code-block:: python
+
+    from dags import get_input_types
+
+    get_input_types(combined)
+
+
+.. code-block:: python
+
+    {"x": float, "y": int, "z": int}

--- a/docs/source/tree_examples.rst
+++ b/docs/source/tree_examples.rst
@@ -36,10 +36,10 @@ that there is a function `f` in this module as well.
         return (f + linear__f) ** 2
 
 The function `h` takes two inputs:
-* `f` from `parabolic.py`, referenced directly as f within the current
-namespace.
-* `f` from `linear.py`, referenced using its namespace with a double
-  underscore separator (`linear__f`).
+
+- `f` from `parabolic.py`, referenced directly as f within the current namespace.
+- `f` from `linear.py`, referenced using its namespace with a double underscore
+  separator (`linear__f`).
 
 Using `concatenate_functions_tree`, we are able to combine the functions from both
 modules.

--- a/src/dags/__init__.py
+++ b/src/dags/__init__.py
@@ -1,4 +1,4 @@
-from dags.dag import concatenate_functions, create_dag, get_ancestors
+from dags.dag import concatenate_functions, create_dag, get_ancestors, get_input_types
 from dags.exceptions import (
     AnnotationMismatchError,
     CyclicDependencyError,
@@ -21,5 +21,6 @@ __all__ = [
     "concatenate_functions",
     "create_dag",
     "get_ancestors",
+    "get_input_types",
     "rename_arguments",
 ]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -614,3 +614,17 @@ def _format_list_linewise(
         ]
         """,
     ).format(formatted_list=formatted_list)
+
+
+def get_input_types(func: GenericCallable) -> dict[str, type]:
+    """Get the input types annotations of a function.
+
+    Args:
+        func: The function to get the input types annotations of.
+
+    Returns
+    -------
+        dict: The argument names and their types annotations of the function.
+    """
+    free_arguments = get_free_arguments(func)
+    return _get_annotations_from_func(func, free_arguments)[0]

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -163,9 +163,8 @@ def functions_without_tree_logic(
 
     In particular, remove all tree logic by
 
-        1. Flattening the set of functions and inputs to qualified absolute names
-        2. Convert all functions so they will only take qualified absolute names as
-           arguments.
+    1. Flattening the set of functions and inputs to qualified absolute names.
+    2. Convert all functions so they take only qualified absolute names as arguments.
 
     The result can be put into `dags.concatenate_functions`.
 
@@ -178,8 +177,8 @@ def functions_without_tree_logic(
 
     Returns
     -------
-        A flat dictionary mapping qualified absolute names to functions taking qualified
-        absolute names as arguments.
+    A flat dictionary mapping qualified absolute names to functions taking qualified
+    absolute names as arguments.
 
     """
     tree_path_functions = flatten_to_tree_paths(functions)

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -159,25 +159,27 @@ def functions_without_tree_logic(
     functions: NestedFunctionDict,
     top_level_namespace: set[str],
 ) -> QualNameFunctionDict:
-    """Return a functions dictionary that `dags.concatenate` functions can work with.
+    """Return a functions dictionary that `dags.concatenate_functions` can work with.
 
     In particular, remove all tree logic by
-    1. Flattening the set of functions and inputs to qualified absolute names
-    2. Convert all functions so they will only take qualified absolute names as
-       arguments.
 
-    The result can be put into `dags.dag.concatenate_functions`.
+        1. Flattening the set of functions and inputs to qualified absolute names
+        2. Convert all functions so they will only take qualified absolute names as
+           arguments.
+
+    The result can be put into `dags.concatenate_functions`.
 
     Args:
-        functions: A nested dictionary of functions. input_structure: A nested
-        dictionary describing the input structure. top_level_namespace: The elements of
-        or not.
+        functions:
+            A nested dictionary of functions.
+        top_level_namespace:
+            The elements of the top-level namespace.
 
 
     Returns
     -------
-        A flat dictionary mapping qualified absolute names to functions taking
-        qualified absolute names as arguments.
+        A flat dictionary mapping qualified absolute names to functions taking qualified
+        absolute names as arguments.
 
     """
     tree_path_functions = flatten_to_tree_paths(functions)

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -9,6 +9,7 @@ from dags.dag import (
     concatenate_functions,
     create_dag,
     get_ancestors,
+    get_input_types,
 )
 from dags.exceptions import CyclicDependencyError
 from dags.typing import (
@@ -274,4 +275,23 @@ def test_get_annotations_from_func() -> None:
 
     got = _get_annotations_from_func(f, free_arguments=["a", "b"])
     exp = {"a": int, "b": float}, float
+    assert got == exp
+
+
+def test_get_input_types() -> None:
+    def f(a: int, b: float) -> float:
+        return 1.0
+
+    got = get_input_types(f)
+    exp = {"a": int, "b": float}
+    assert got == exp
+
+
+def test_get_input_types_partial() -> None:
+    def f(a: int, b: float) -> float:
+        return 1.0
+
+    partial_f = partial(f, a=1)
+    got = get_input_types(partial_f)
+    exp = {"b": float}
     assert got == exp


### PR DESCRIPTION
Implements and adds the `get_input_types` function to the top-level namespace of `dags`.

Additionally, I add a section to the documentation introducing the `set_annotations` feature.

This tackles one of the two remaining points in #21. Instead of `create_input_types`, I propose `get_input_types`, since the types already exist in the function signature.