### PR TITLE
Sort the outputs of the top-level namespace and format line-wise.

### DIFF
--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -18,7 +18,7 @@ from dags.output import aggregated_output, dict_output, list_output, single_outp
 from dags.signature import with_signature
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from dags.typing import (
         CombinedFunctionReturnType,
@@ -329,7 +329,7 @@ def _fail_if_functions_are_missing(
 ) -> None:
     targets_not_in_functions = set(targets) - set(functions)
     if targets_not_in_functions:
-        formatted = _format_list_linewise(list(targets_not_in_functions))
+        formatted = format_list_linewise(list(targets_not_in_functions))
         msg = f"The following targets have no corresponding function:\n{formatted}"
         raise MissingFunctionsError(msg)
 
@@ -339,7 +339,7 @@ def _fail_if_dag_contains_cycle(dag: nx.DiGraph[str]) -> None:
     cycles = list(nx.simple_cycles(dag))
 
     if len(cycles) > 0:
-        formatted = _format_list_linewise(cycles)
+        formatted = format_list_linewise(cycles)
         msg = f"The DAG contains one or more cycles:\n{formatted}"
         raise CyclicDependencyError(msg)
 
@@ -603,10 +603,8 @@ def _get_annotations_from_execution_info(
     return args, cast("tuple[type, ...]", return_annotation)
 
 
-def _format_list_linewise(
-    list_: list[object],
-) -> str:
-    formatted_list = '",\n    "'.join([str(c) for c in list_])
+def format_list_linewise(seq: Sequence[object]) -> str:
+    formatted_list = '",\n    "'.join([str(c) for c in seq])
     return textwrap.dedent(
         """
         [

--- a/src/dags/tree/validation.py
+++ b/src/dags/tree/validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from dags.dag import format_list_linewise
 from dags.tree.exceptions import (
     RepeatedTopLevelElementError,
     TrailingUnderscoreError,
@@ -150,7 +151,8 @@ def fail_if_top_level_elements_repeated_in_paths(
         msg = (
             "Elements of the top-level namespace must not be repeated further down "
             f"in the hierarchy. Offending path(s):\n\n{paths}\n\n\n"
-            f"Top-level namespace:\n\n{top_level_namespace}"
+            "Top-level namespace:\n\n"
+            f"{format_list_linewise(sorted(top_level_namespace))}"
         )
         raise RepeatedTopLevelElementError(msg)
 


### PR DESCRIPTION
- In principle, just a trivial change to `dags.tree.validation.fail_if_top_level_elements_repeated_in_paths`. 
- Reason: Turns out it was pretty hard to read an error message with a medium-sized top-level namespace
- Slight changes to make `dag.format_list_linewise` public and please mypy by annotating it with `Sequence` instead of `list`.

@timmens, asking you for the review just so you see this before continuing; should be orthogonal though.