### PR TITLE
Refactor annotation handling

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -252,3 +252,80 @@ We can simply rename the arguments programmatically:
 .. code-block:: python
 
     0.6
+
+
+Utilizing type annotations
+--------------------------
+
+If your functions have type annotations, dags can use this information to infer the
+types of the inputs and outputs of the combined function. To activate this feature, set
+the ``set_annotations`` parameter to ``True`` when calling ``concatenate_functions``.
+
+Let's return to the first example and add type annotations:
+
+
+.. code-block:: python
+
+    def f(x: float, y: int) -> float:
+        return x**2 + y**2
+
+
+    def g(y: int, z: int) -> int:
+        return 0.5 * y * z
+
+
+    def h(f: float, g: int) -> float:
+        return g / f
+
+    combined = concatenate_functions(
+        [f, g, h],
+        targets="h",
+        set_annotations=True,
+    )
+
+
+We can inspect the signature of the combined function to see the type annotations:
+
+.. code-block:: python
+
+    import inspect
+    inspect.signature(combined)
+
+
+.. code-block:: python
+
+    <Signature (x: float, y: int, z: int) -> float>
+
+.. note::
+
+    If the type annotations are not consistent across the functions, dags will raise an
+    error. In the above example, if instead of ``g(y: int, z: int)`` we had written:
+
+    .. code-block:: python
+
+        def g(y: bool, z: int) -> int:
+            return 0.5 * y * z
+
+
+    the result would have been:
+
+    .. code-block:: pytb
+
+        dags.exceptions.AnnotationMismatchError:
+        function g has the argument type annotation 'y: bool',
+        but type annotation 'y: int' is used elsewhere.
+
+In many cases, it is useful to get the type annotations of the input arguments of the
+combined function in form of a dictionary. This can be achieved easily using the
+``get_input_types`` function:
+
+.. code-block:: python
+
+    from dags import get_input_types
+
+    get_input_types(combined)
+
+
+.. code-block:: python
+
+    {"x": float, "y": int, "z": int}

--- a/docs/source/tree_examples.rst
+++ b/docs/source/tree_examples.rst
@@ -36,10 +36,10 @@ that there is a function `f` in this module as well.
         return (f + linear__f) ** 2
 
 The function `h` takes two inputs:
-* `f` from `parabolic.py`, referenced directly as f within the current
-namespace.
-* `f` from `linear.py`, referenced using its namespace with a double
-  underscore separator (`linear__f`).
+
+- `f` from `parabolic.py`, referenced directly as f within the current namespace.
+- `f` from `linear.py`, referenced using its namespace with a double underscore
+  separator (`linear__f`).
 
 Using `concatenate_functions_tree`, we are able to combine the functions from both
 modules.

--- a/pixi.lock
+++ b/pixi.lock
@@ -4637,8 +4637,8 @@ packages:
   timestamp: 1736761414276
 - pypi: .
   name: dags
-  version: 0.3.1.dev8+gf92b174.d20250506
-  sha256: 77b4280d6e1d82d2335e7748892fe0c08d8952cb6a7bf6bfcb0e5cbbf3932cbf
+  version: 0.3.1.dev39+g9020203.d20250521
+  sha256: 53ca7b9f34529ef19fe19ac904bdaaccf6ab50b74f91a645fbaae5e0c41b81c8
   requires_dist:
   - flatten-dict
   - networkx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ extend-ignore = [
     "ANN003",  # missing type annotation for `**kwargs`
     "ANN201",  # missing return type annotation for public function
     "ANN202",  # missing return type annotation for private function
+    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed in `return_annotation`
     "D100",  # missing docstring in public module
     "D103",  # missing docstring in public function
     "D104",  # missing docstring in public package

--- a/src/dags/__init__.py
+++ b/src/dags/__init__.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from dags.dag import concatenate_functions, create_dag, get_ancestors, get_annotations
+from dags.dag import (
+    concatenate_functions,
+    create_dag,
+    get_ancestors,
+    get_annotations,
+    get_free_arguments,
+)
 from dags.exceptions import (
     AnnotationMismatchError,
     CyclicDependencyError,
@@ -24,5 +30,6 @@ __all__ = [
     "create_dag",
     "get_ancestors",
     "get_annotations",
+    "get_free_arguments",
     "rename_arguments",
 ]

--- a/src/dags/__init__.py
+++ b/src/dags/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dags.dag import concatenate_functions, create_dag, get_ancestors, get_input_types
 from dags.exceptions import (
     AnnotationMismatchError,

--- a/src/dags/__init__.py
+++ b/src/dags/__init__.py
@@ -1,4 +1,4 @@
-from dags.dag import concatenate_functions, create_dag, get_ancestors
+from dags.dag import concatenate_functions, create_dag, get_ancestors, get_input_types
 from dags.exceptions import (
     AnnotationMismatchError,
     CyclicDependencyError,
@@ -21,5 +21,6 @@ __all__ = [
     "concatenate_functions",
     "create_dag",
     "get_ancestors",
+    "get_input_types",
     "rename_arguments",
 ]

--- a/src/dags/__init__.py
+++ b/src/dags/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dags.dag import concatenate_functions, create_dag, get_ancestors, get_input_types
+from dags.dag import concatenate_functions, create_dag, get_ancestors, get_annotations
 from dags.exceptions import (
     AnnotationMismatchError,
     CyclicDependencyError,
@@ -23,6 +23,6 @@ __all__ = [
     "concatenate_functions",
     "create_dag",
     "get_ancestors",
-    "get_input_types",
+    "get_annotations",
     "rename_arguments",
 ]

--- a/src/dags/__init__.py
+++ b/src/dags/__init__.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+from dags.annotations import get_annotations, get_free_arguments
 from dags.dag import (
     concatenate_functions,
     create_dag,
     get_ancestors,
-    get_annotations,
-    get_free_arguments,
 )
 from dags.exceptions import (
     AnnotationMismatchError,

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -57,10 +57,6 @@ def get_annotations(
         A dictionary with the argument names as keys and the type annotations as values.
         The type annotations are strings if eval_str is False, otherwise they are types.
 
-    Raises
-    ------
-        NonStringAnnotationError: If the type annotations are not strings.
-
     """
     if default is None:
         default = inspect.Parameter.empty if eval_str else "unknown_type"

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -71,3 +71,7 @@ def get_annotations(
         annotations = inspect.get_annotations(func, eval_str=eval_str)
     free_arguments = get_free_arguments(func)
     return {arg: annotations.get(arg, default) for arg in ["return", *free_arguments]}
+
+
+def get_str_repr(obj: object) -> str:
+    return getattr(obj, "__name__", str(obj))

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -45,7 +45,10 @@ def get_annotations(
     eval_str: bool = False,
     default: str | type | None = None,
 ) -> dict[str, str] | dict[str, type]:
-    """Thin wrapper around inspect.get_annotations to also handle partialled funcs.
+    """Thin wrapper around inspect.get_annotations.
+
+    Compared to inspect.get_annotations, this function also handles partialled funcs,
+    and it returns annotations for all arguments, not just the ones with annotations.
 
     Args:
         func: The function to get annotations from.

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, overload
 
+from dags.exceptions import NonStringAnnotationError
+
 if TYPE_CHECKING:
     from dags.typing import GenericCallable
 
@@ -50,7 +52,7 @@ def get_annotations(
         eval_str: If True, the string type annotations are evaluated.
         default: The default value to use if an annotation is missing. If None, the
             default value is inspect.Parameter.empty if eval_str is True, otherwise
-            "unknown_type".
+            "no_annotation_found".
 
     Returns
     -------
@@ -59,7 +61,7 @@ def get_annotations(
 
     """
     if default is None:
-        default = inspect.Parameter.empty if eval_str else "unknown_type"
+        default = inspect.Parameter.empty if eval_str else "no_annotation_found"
 
     if isinstance(func, functools.partial):
         annotations = inspect.get_annotations(func.func, eval_str=eval_str)
@@ -71,3 +73,62 @@ def get_annotations(
 
 def get_str_repr(obj: object) -> str:
     return getattr(obj, "__name__", str(obj))
+
+
+def verify_annotations_are_strings(
+    annotations: dict[str, str], function_name: str
+) -> None:
+    # If all annotations are strings, we are done.
+    if all(isinstance(v, str) for v in annotations.values()):
+        return
+
+    non_string_annotations = [k for k, v in annotations.items() if isinstance(v, type)]
+    arg_annotations = {k: v for k, v in annotations.items() if k != "return"}
+    return_annotation = annotations["return"]
+
+    # Create a representation of the signature with string annotations
+    # ----------------------------------------------------------------------------------
+    stringified_arg_annotations = []
+    for k, v in arg_annotations.items():
+        if k in non_string_annotations:
+            stringified_arg_annotations.append(f"{k}: '{get_str_repr(v)}'")
+        else:
+            annot = f"{k}: '{v}'"
+            stringified_arg_annotations.append(annot)
+
+    if "return" in non_string_annotations:
+        stringified_return_annotation = f"'{get_str_repr(return_annotation)}'"
+    else:
+        stringified_return_annotation = f"'{return_annotation}'"
+
+    stringified_signature = (
+        f"{function_name}({', '.join(stringified_arg_annotations)}) -> "
+        f"{stringified_return_annotation}"
+    )
+
+    # Create message on which argument and/or return annotation is invalid
+    # ----------------------------------------------------------------------------------
+    invalid_arg_annotations = [k for k in non_string_annotations if k != "return"]
+    if invalid_arg_annotations:
+        s = "s" if len(invalid_arg_annotations) > 1 else ""
+        invalid_arg_msg = f"argument{s} ({', '.join(invalid_arg_annotations)})"
+    else:
+        invalid_arg_msg = ""
+
+    invalid_annotations_msg = ""
+    if invalid_arg_msg and "return" in non_string_annotations:
+        invalid_annotations_msg = f"{invalid_arg_msg} and the return value"
+    elif invalid_arg_msg:
+        invalid_annotations_msg = invalid_arg_msg
+    elif "return" in non_string_annotations:
+        invalid_annotations_msg = "return value"
+
+    # Raise the error
+    # ----------------------------------------------------------------------------------
+    raise NonStringAnnotationError(
+        f"All function annotations must be strings. The annotations for the "
+        f"{invalid_annotations_msg} are not strings.\nA simple way for Python to treat "
+        "type annotations as strings is to add\n\n\tfrom __future__ import annotations"
+        "\n\nat the top of your file. Alternatively, you can do it manually by "
+        f"enclosing the annotations in quotes:\n\n\t{stringified_signature}."
+    )

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dags.typing import GenericCallable
+
+import functools
+import inspect
+
+
+def get_free_arguments(
+    func: GenericCallable,
+) -> list[str]:
+    arguments = list(inspect.signature(func).parameters)
+    if isinstance(func, functools.partial):
+        # arguments that are partialled by position are not part of the signature
+        # anyways, so they do not need special handling.
+        non_free = set(func.keywords)
+        arguments = [arg for arg in arguments if arg not in non_free]
+
+    return arguments
+
+
+def get_annotations(
+    func: GenericCallable,
+    eval_str: bool = False,
+    default: str = "unknown_type",
+) -> dict[str, str]:
+    """Thin wrapper around inspect.get_annotations to also handle partialled funcs.
+
+    Args:
+        func: The function to get annotations from.
+        eval_str: If True, the string type annotations are evaluated.
+        default: The default value to use if an annotation is missing.
+
+    Returns
+    -------
+        A dictionary with the argument names as keys and the type annotations as values.
+        The type annotations are strings.
+
+    Raises
+    ------
+        NonStringAnnotationError: If the type annotations are not strings.
+
+    """
+    if isinstance(func, functools.partial):
+        annotations = inspect.get_annotations(func.func, eval_str=eval_str)
+    else:
+        annotations = inspect.get_annotations(func, eval_str=eval_str)
+    free_arguments = get_free_arguments(func)
+    return {arg: annotations.get(arg, default) for arg in ["return", *free_arguments]}

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 if TYPE_CHECKING:
     from dags.typing import GenericCallable
@@ -22,28 +22,49 @@ def get_free_arguments(
     return arguments
 
 
+@overload
+def get_annotations(
+    func: GenericCallable,
+    eval_str: Literal[False] = False,
+    default: str | None = None,
+) -> dict[str, str]: ...
+
+
+@overload
+def get_annotations(
+    func: GenericCallable,
+    eval_str: Literal[True] = True,
+    default: type | None = None,
+) -> dict[str, type]: ...
+
+
 def get_annotations(
     func: GenericCallable,
     eval_str: bool = False,
-    default: str = "unknown_type",
-) -> dict[str, str]:
+    default: str | type | None = None,
+) -> dict[str, str] | dict[str, type]:
     """Thin wrapper around inspect.get_annotations to also handle partialled funcs.
 
     Args:
         func: The function to get annotations from.
         eval_str: If True, the string type annotations are evaluated.
-        default: The default value to use if an annotation is missing.
+        default: The default value to use if an annotation is missing. If None, the
+            default value is inspect.Parameter.empty if eval_str is True, otherwise
+            "unknown_type".
 
     Returns
     -------
         A dictionary with the argument names as keys and the type annotations as values.
-        The type annotations are strings.
+        The type annotations are strings if eval_str is False, otherwise they are types.
 
     Raises
     ------
         NonStringAnnotationError: If the type annotations are not strings.
 
     """
+    if default is None:
+        default = inspect.Parameter.empty if eval_str else "unknown_type"
+
     if isinstance(func, functools.partial):
         annotations = inspect.get_annotations(func.func, eval_str=eval_str)
     else:

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -64,7 +64,7 @@ def get_annotations(
 
     """
     if default is None:
-        default = inspect.Parameter.empty if eval_str else "no_annotation_found"
+        default = inspect.Parameter.empty if eval_str else "None"
 
     if isinstance(func, functools.partial):
         annotations = inspect.get_annotations(func.func, eval_str=eval_str)

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -64,7 +64,7 @@ def get_annotations(
 
     """
     if default is None:
-        default = inspect.Parameter.empty if eval_str else "None"
+        default = inspect.Parameter.empty if eval_str else "no_annotation_found"
 
     if isinstance(func, functools.partial):
         annotations = inspect.get_annotations(func.func, eval_str=eval_str)
@@ -72,10 +72,6 @@ def get_annotations(
         annotations = inspect.get_annotations(func, eval_str=eval_str)
     free_arguments = get_free_arguments(func)
     return {arg: annotations.get(arg, default) for arg in ["return", *free_arguments]}
-
-
-def get_str_repr(obj: object) -> str:
-    return getattr(obj, "__name__", str(obj))
 
 
 def verify_annotations_are_strings(
@@ -94,13 +90,13 @@ def verify_annotations_are_strings(
     stringified_arg_annotations = []
     for k, v in arg_annotations.items():
         if k in non_string_annotations:
-            stringified_arg_annotations.append(f"{k}: '{get_str_repr(v)}'")
+            stringified_arg_annotations.append(f"{k}: '{_get_str_repr(v)}'")
         else:
             annot = f"{k}: '{v}'"
             stringified_arg_annotations.append(annot)
 
     if "return" in non_string_annotations:
-        stringified_return_annotation = f"'{get_str_repr(return_annotation)}'"
+        stringified_return_annotation = f"'{_get_str_repr(return_annotation)}'"
     else:
         stringified_return_annotation = f"'{return_annotation}'"
 
@@ -126,8 +122,6 @@ def verify_annotations_are_strings(
     elif "return" in non_string_annotations:
         invalid_annotations_msg = "return value"
 
-    # Raise the error
-    # ----------------------------------------------------------------------------------
     raise NonStringAnnotationError(
         f"All function annotations must be strings. The annotations for the "
         f"{invalid_annotations_msg} are not strings.\nA simple way for Python to treat "
@@ -135,3 +129,7 @@ def verify_annotations_are_strings(
         "\n\nat the top of your file. Alternatively, you can do it manually by "
         f"enclosing the annotations in quotes:\n\n\t{stringified_signature}."
     )
+
+
+def _get_str_repr(obj: object) -> str:
+    return getattr(obj, "__name__", str(obj))

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import networkx as nx
 
-from dags.annotations import get_annotations, get_free_arguments
+from dags.annotations import get_annotations, get_free_arguments, get_str_repr
 from dags.exceptions import (
     AnnotationMismatchError,
     CyclicDependencyError,
@@ -618,13 +618,13 @@ def _verify_annotations_are_strings(
     stringified_arg_annotations = []
     for k, v in arg_annotations.items():
         if k in non_string_annotations:
-            stringified_arg_annotations.append(f"{k}: '{_get_object_name(v)}'")
+            stringified_arg_annotations.append(f"{k}: '{get_str_repr(v)}'")
         else:
             annot = f"{k}: '{v}'"
             stringified_arg_annotations.append(annot)
 
     if "return" in non_string_annotations:
-        stringified_return_annotation = f"'{_get_object_name(return_annotation)}'"
+        stringified_return_annotation = f"'{get_str_repr(return_annotation)}'"
     else:
         stringified_return_annotation = f"'{return_annotation}'"
 
@@ -659,7 +659,3 @@ def _verify_annotations_are_strings(
         "\n\nat the top of your file. Alternatively, you can do it manually by "
         f"enclosing the annotations in quotes:\n\n\t{stringified_signature}."
     )
-
-
-def _get_object_name(obj: object) -> str:
-    return getattr(obj, "__name__", str(obj))

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -124,6 +124,13 @@ def concatenate_functions(
         function: A function that produces targets when called with suitable arguments.
 
     """
+    if set_annotations and not isinstance(targets, str) and aggregator is not None:
+        raise DagsError(
+            "Cannot set annotations when using an aggregator on multiple targets. "
+            "Please set set_annotations to False, or use a single target, or do not "
+            "use an aggregator."
+        )
+
     # Create the DAG.
     dag = create_dag(functions, targets)
 

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -126,11 +126,14 @@ def concatenate_functions(
             Enforcing the signature has a small runtime overhead.
         set_annotations (bool): If True, we set the annotations of the concatenated
             function using the annotations of the functions that are used to generate
-            the targets. In case of a type mismatch, an error is raised. Type
-            annotations must be strings, else a NonStringAnnotationError is raised.
-            Either enclose the annotations in quotes or add
-            "from __future__ import annotations" at the top of your file.
-
+            the targets. Type annotations must be strings, else a
+            NonStringAnnotationError is raised. Either enclose the annotations in quotes
+            or add "from __future__ import annotations" at the top of your file. The
+            return annotation of the concatenated function will be a string, tuple,
+            list, or dict, depending on the return type and the number of targets.
+            Importantly, the return annotation is not a valid type annotation, but
+            designed to communicate as much information on the target types as
+            possible.
 
     Returns
     -------
@@ -230,12 +233,14 @@ def _create_combined_function_from_dag(
             Enforcing the signature has a small runtime overhead.
         set_annotations (bool): If True, we set the annotations of the concatenated
             function using the annotations of the functions that are used to generate
-            the targets. In case of a type mismatch, an error is raised. Type
-            annotations must be strings, else a NonStringAnnotationError is raised.
-            Either enclose the annotations in quotes or add
-            "from __future__ import annotations" at the top of your file. If you do not
-            have direct control over some function, you can wrap it in an annotated
-            version.
+            the targets. Type annotations must be strings, else a
+            NonStringAnnotationError is raised. Either enclose the annotations in quotes
+            or add "from __future__ import annotations" at the top of your file. The
+            return annotation of the concatenated function will be a string, tuple,
+            list, or dict, depending on the return type and the number of targets.
+            Importantly, the return annotation is not a valid type annotation, but
+            designed to communicate as much information on the target types as
+            possible.
 
     Returns
     -------
@@ -529,9 +534,16 @@ def _create_concatenated_function(
         enforce_signature: If True, the signature of the concatenated function
             is enforced. Otherwise it is only provided for introspection purposes.
             Enforcing the signature has a small runtime overhead.
-        set_annotations: If True, we set the annotations of the concatenated
+        set_annotations (bool): If True, we set the annotations of the concatenated
             function using the annotations of the functions that are used to generate
-            the targets. In case of a type mismatch, an error is raised.
+            the targets. Type annotations must be strings, else a
+            NonStringAnnotationError is raised. Either enclose the annotations in quotes
+            or add "from __future__ import annotations" at the top of your file. The
+            return annotation of the concatenated function will be a string, tuple,
+            list, or dict, depending on the return type and the number of targets.
+            Importantly, the return annotation is not a valid type annotation, but
+            designed to communicate as much information on the target types as
+            possible.
 
     Returns
     -------

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -46,11 +46,15 @@ class FunctionExecutionInfo:
             coincides with the __annotations__ attribute of the function. For partialled
             functions, this is a dictionary with the names of the free arguments as keys
             and their expected types as values, as well as the return type of the
-            function stored under the key "return". We assume that the type annotations
-            are strings.
+            function stored under the key "return". Type annotations must be strings,
+            else a NonStringAnnotationError is raised.
         arguments: The names of the arguments of the function.
         argument_annotations: The argument annotations of the function.
         return_annotation: The return annotation of the function.
+
+    Raises
+    ------
+        NonStringAnnotationError: If the type annotations are not strings.
 
     """
 

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -120,7 +120,10 @@ def concatenate_functions(
             Enforcing the signature has a small runtime overhead.
         set_annotations (bool): If True, we set the annotations of the concatenated
             function using the annotations of the functions that are used to generate
-            the targets. In case of a type mismatch, an error is raised.
+            the targets. In case of a type mismatch, an error is raised. Type
+            annotations must be strings, else a NonStringAnnotationError is raised.
+            Either enclose the annotations in quotes or add
+            "from __future__ import annotations" at the top of your file.
 
 
     Returns
@@ -221,7 +224,10 @@ def _create_combined_function_from_dag(
             Enforcing the signature has a small runtime overhead.
         set_annotations (bool): If True, we set the annotations of the concatenated
             function using the annotations of the functions that are used to generate
-            the targets. In case of a type mismatch, an error is raised.
+            the targets. In case of a type mismatch, an error is raised. Type
+            annotations must be strings, else a NonStringAnnotationError is raised.
+            Either enclose the annotations in quotes or add
+            "from __future__ import annotations" at the top of your file.
 
     Returns
     -------

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -501,7 +501,7 @@ def _create_concatenated_function(
 
     """
     args: list[str] | dict[str, str]
-    return_annotation: type[inspect.Parameter.empty] | str
+    return_annotation: type[inspect._empty] | str
 
     if set_annotations:
         args, return_annotation = get_annotations_from_execution_info(
@@ -516,7 +516,7 @@ def _create_concatenated_function(
     @with_signature(
         args=args,
         enforce=enforce_signature,
-        return_annotation=return_annotation,  # type: ignore[arg-type]
+        return_annotation=return_annotation,
     )
     def concatenated(*args: Any, **kwargs: Any) -> tuple[Any, ...]:  # noqa: ANN401
         results = {**dict(zip(arglist, args, strict=False)), **kwargs}
@@ -617,13 +617,13 @@ def _verify_annotations_are_strings(
     stringified_arg_annotations = []
     for k, v in arg_annotations.items():
         if k in non_string_annotations:
-            stringified_arg_annotations.append(f"{k}: '{v.__name__}'")
+            stringified_arg_annotations.append(f"{k}: '{_get_object_name(v)}'")
         else:
             annot = f"{k}: '{v}'"
             stringified_arg_annotations.append(annot)
 
     if "return" in non_string_annotations:
-        stringified_return_annotation = f"'{return_annotation.__name__}'"
+        stringified_return_annotation = f"'{_get_object_name(return_annotation)}'"
     else:
         stringified_return_annotation = f"'{return_annotation}'"
 
@@ -658,3 +658,7 @@ def _verify_annotations_are_strings(
         "\n\nat the top of your file. Alternatively, you can do it manually by "
         f"enclosing the annotations in quotes:\n\n\t{stringified_signature}."
     )
+
+
+def _get_object_name(obj: object) -> str:
+    return getattr(obj, "__name__", str(obj))

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -621,7 +621,15 @@ def get_annotations_from_execution_info(
 
     args = {k: v for k, v in types.items() if k in arglist}
     if targets:
-        return_annotation = f"tuple[{', '.join(types[target] for target in targets)}]"
+        _target_types = [types[target] for target in targets if target in types]
+        target_types = [
+            # We need to wrap the "None" "type" in quotes for it to be
+            # interpreted as a string, as it will be evaluated later on, which fails if
+            # it is not a string.
+            tt if tt != "None" else "'None'"
+            for tt in _target_types
+        ]
+        return_annotation = f"tuple[{', '.join(target_types)}]"
     else:
         return_annotation = "()"
     return args, return_annotation

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -484,7 +484,8 @@ def _create_concatenated_function(
 
     Returns
     -------
-        The concatenated function
+        - The concatenated function
+        - The input types of the concatenated function
 
     """
     args: list[str] | dict[str, type]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -501,7 +501,7 @@ def _create_concatenated_function(
 
     """
     args: list[str] | dict[str, str]
-    return_annotation: str | tuple[str, ...]
+    return_annotation: type[inspect.Parameter.empty] | str
 
     if set_annotations:
         args, return_annotation = get_annotations_from_execution_info(
@@ -534,7 +534,7 @@ def get_annotations_from_execution_info(
     execution_info: dict[str, FunctionExecutionInfo],
     arglist: list[str],
     targets: list[str],
-) -> tuple[dict[str, str], tuple[str, ...]]:
+) -> tuple[dict[str, str], str]:
     """Get the (argument and return) annotations of the concatenated function.
 
     Args:
@@ -546,7 +546,7 @@ def get_annotations_from_execution_info(
     Returns
     -------
         - Dictionary with argnames as keys and their expected types as values
-        - The expected type of the return value(s) as a tuple.
+        - The expected type of the return value(s) as a string.
 
     Raises
     ------

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -484,8 +484,7 @@ def _create_concatenated_function(
 
     Returns
     -------
-        - The concatenated function
-        - The input types of the concatenated function
+        The concatenated function
 
     """
     args: list[str] | dict[str, type]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -614,3 +614,17 @@ def _format_list_linewise(
         ]
         """,
     ).format(formatted_list=formatted_list)
+
+
+def get_input_types(func: GenericCallable) -> dict[str, type]:
+    """Get the input types annotations of a function.
+
+    Args:
+        func: The function to get the input types annotations of.
+
+    Returns
+    -------
+        dict: The argument names and their types annotations of the function.
+    """
+    free_arguments = get_free_arguments(func)
+    return _get_annotations_from_func(func, free_arguments)[0]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -644,11 +644,11 @@ def _verify_annotations_are_strings(
 
     invalid_annotations_msg = ""
     if invalid_arg_msg and "return" in non_string_annotations:
-        invalid_annotations_msg = f"{invalid_arg_msg} and the return annotation"
+        invalid_annotations_msg = f"{invalid_arg_msg} and the return value"
     elif invalid_arg_msg:
         invalid_annotations_msg = invalid_arg_msg
     elif "return" in non_string_annotations:
-        invalid_annotations_msg = "the return annotation"
+        invalid_annotations_msg = "return value"
 
     # Raise the error
     # ----------------------------------------------------------------------------------

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -698,19 +698,19 @@ def _verify_annotations_are_strings(
     else:
         invalid_arg_msg = ""
 
-    invalid_annotation_msg = ""
+    invalid_annotations_msg = ""
     if invalid_arg_msg and "return" in non_string_annotations:
-        invalid_annotation_msg = f"{invalid_arg_msg} and the return annotation"
+        invalid_annotations_msg = f"{invalid_arg_msg} and the return annotation"
     elif invalid_arg_msg:
-        invalid_annotation_msg = invalid_arg_msg
+        invalid_annotations_msg = invalid_arg_msg
     elif "return" in non_string_annotations:
-        invalid_annotation_msg = "the return annotation"
+        invalid_annotations_msg = "the return annotation"
 
     # Raise the error
     # ----------------------------------------------------------------------------------
     raise NonStringAnnotationError(
         f"All function annotations must be strings. The annotations for the "
-        f"{invalid_annotation_msg} are not strings.\nA simple way for Python to treat "
+        f"{invalid_annotations_msg} are not strings.\nA simple way for Python to treat "
         "type annotations as strings is to add\n\n\tfrom __future__ import annotations"
         "\n\nat the top of your file. Alternatively, you can do it manually by "
         f"enclosing the annotations in quotes:\n\n\t{stringified_signature}."

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -655,7 +655,7 @@ def _get_annotations_partialled_func(
     """
     annotations = inspect.get_annotations(func.func, eval_str=eval_str)
     free_arguments = get_free_arguments(func)
-    return {arg: annotations[arg] for arg in free_arguments}
+    return {arg: annotations[arg] for arg in ["return", *free_arguments]}
 
 
 def _verify_annotations_are_strings(

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -620,7 +620,10 @@ def get_annotations_from_execution_info(
         types.update(info.argument_annotations)
 
     args = {k: v for k, v in types.items() if k in arglist}
-    return_annotation = f"tuple[{', '.join(types[target] for target in targets)}]"
+    if targets:
+        return_annotation = f"tuple[{', '.join(types[target] for target in targets)}]"
+    else:
+        return_annotation = "()"
     return args, return_annotation
 
 

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -234,17 +234,26 @@ def _create_combined_function_from_dag(
 
     # Return function in specified format.
     if isinstance(targets, str) or (aggregator is not None and len(_targets) == 1):
-        out = cast("GenericCallable", single_output(_concatenated))
+        out = cast(
+            "GenericCallable",
+            single_output(_concatenated, set_annotations=set_annotations),
+        )
     elif aggregator is not None:
         out = cast(
             "GenericCallable", aggregated_output(_concatenated, aggregator=aggregator)
         )
     elif return_type == "list":
-        out = cast("GenericCallable", list_output(_concatenated))
+        out = cast(
+            "GenericCallable",
+            list_output(_concatenated, set_annotations=set_annotations),
+        )
     elif return_type == "tuple":
         out = _concatenated
     elif return_type == "dict":
-        out = cast("GenericCallable", dict_output(_concatenated, keys=_targets))
+        out = cast(
+            "GenericCallable",
+            dict_output(_concatenated, keys=_targets, set_annotations=set_annotations),
+        )
     else:
         msg = (
             f"Invalid return type {return_type}. Must be 'list', 'tuple', or 'dict'. "

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -164,7 +164,7 @@ def create_dag(
 
     """
     # Harmonize and check arguments.
-    _functions, _targets = _harmonize_and_check_functions_and_targets(
+    _functions, _targets = harmonize_and_check_functions_and_targets(
         functions,
         targets,
     )
@@ -218,13 +218,13 @@ def _create_combined_function_from_dag(
 
     """
     # Harmonize and check arguments.
-    _functions, _targets = _harmonize_and_check_functions_and_targets(
+    _functions, _targets = harmonize_and_check_functions_and_targets(
         functions,
         targets,
     )
 
     _arglist = create_arguments_of_concatenated_function(_functions, dag)
-    _exec_info = _create_execution_info(_functions, dag)
+    _exec_info = create_execution_info(_functions, dag)
     _concatenated = _create_concatenated_function(
         _exec_info,
         _arglist,
@@ -285,7 +285,7 @@ def get_ancestors(
 
     """
     # Harmonize and check arguments.
-    _functions, _targets = _harmonize_and_check_functions_and_targets(
+    _functions, _targets = harmonize_and_check_functions_and_targets(
         functions,
         targets,
     )
@@ -301,7 +301,7 @@ def get_ancestors(
     return ancestors
 
 
-def _harmonize_and_check_functions_and_targets(
+def harmonize_and_check_functions_and_targets(
     functions: FunctionCollection,
     targets: TargetType,
 ) -> tuple[dict[str, GenericCallable], list[str]]:
@@ -450,7 +450,7 @@ def create_arguments_of_concatenated_function(
     return sorted(all_nodes - function_names)
 
 
-def _create_execution_info(
+def create_execution_info(
     functions: dict[str, GenericCallable],
     dag: nx.DiGraph[str],
 ) -> dict[str, FunctionExecutionInfo]:
@@ -504,7 +504,7 @@ def _create_concatenated_function(
     return_annotation: str | tuple[str, ...]
 
     if set_annotations:
-        args, return_annotation = _get_annotations_from_execution_info(
+        args, return_annotation = get_annotations_from_execution_info(
             execution_info,
             arglist=arglist,
             targets=targets,
@@ -530,7 +530,7 @@ def _create_concatenated_function(
     return concatenated
 
 
-def _get_annotations_from_execution_info(
+def get_annotations_from_execution_info(
     execution_info: dict[str, FunctionExecutionInfo],
     arglist: list[str],
     targets: list[str],

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -545,8 +545,9 @@ def get_annotations_from_execution_info(
 
     Returns
     -------
-        - Dictionary with argnames as keys and their expected types as values
-        - The expected type of the return value(s) as a string.
+        - Dictionary with argnames as keys and their expected types in string format as
+          values.
+        - The expected type of the return value as a string.
 
     Raises
     ------

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -58,7 +58,8 @@ class FunctionExecutionInfo:
 
     Raises
     ------
-        NonStringAnnotationError: If the type annotations are not strings.
+        NonStringAnnotationError: If `verify_annotations` is `True` and the type
+            annotations are not strings.
 
     """
 
@@ -124,20 +125,28 @@ def concatenate_functions(
         enforce_signature (bool): If True, the signature of the concatenated function
             is enforced. Otherwise it is only provided for introspection purposes.
             Enforcing the signature has a small runtime overhead.
-        set_annotations (bool): If True, we set the annotations of the concatenated
-            function using the annotations of the functions that are used to generate
-            the targets. Type annotations must be strings, else a
-            NonStringAnnotationError is raised. Either enclose the annotations in quotes
-            or add "from __future__ import annotations" at the top of your file. The
-            return annotation of the concatenated function will be a string, tuple,
-            list, or dict, depending on the return type and the number of targets.
-            Importantly, the return annotation is not a valid type annotation, but
-            designed to communicate as much information on the target types as
-            possible.
+        set_annotations (bool): If True, sets the annotations of the concatenated
+            function based on those of the functions used to generate the targets. The
+            return annotation of the concatenated function reflects the requested return
+            type and number of targets (e.g., for two targets returned as a list, the
+            return annotation is a list of their respective type hints). Note that this
+            is not a valid type annotation and should not be used for type checking. All
+            annotations must be strings; otherwise, a NonStringAnnotationError is
+            raised. To ensure string annotations, enclose them in quotes or use "from
+            __future__ import annotations" at the top of your file. An
+            AnnotationMismatchError is raised if annotations differ between functions.
 
     Returns
     -------
         function: A function that produces targets when called with suitable arguments.
+
+    Raises
+    ------
+        - NonStringAnnotationError: If `set_annotations` is `True` and the type
+            annotations are not strings.
+
+        - AnnotationMismatchError: If `set_annotations` is `True` and there are
+            incompatible annotations in the DAG's components.
 
     """
     if set_annotations and not isinstance(targets, str) and aggregator is not None:
@@ -231,20 +240,28 @@ def _create_combined_function_from_dag(
         enforce_signature (bool): If True, the signature of the concatenated function
             is enforced. Otherwise it is only provided for introspection purposes.
             Enforcing the signature has a small runtime overhead.
-        set_annotations (bool): If True, we set the annotations of the concatenated
-            function using the annotations of the functions that are used to generate
-            the targets. Type annotations must be strings, else a
-            NonStringAnnotationError is raised. Either enclose the annotations in quotes
-            or add "from __future__ import annotations" at the top of your file. The
-            return annotation of the concatenated function will be a string, tuple,
-            list, or dict, depending on the return type and the number of targets.
-            Importantly, the return annotation is not a valid type annotation, but
-            designed to communicate as much information on the target types as
-            possible.
+        set_annotations (bool): If True, sets the annotations of the concatenated
+            function based on those of the functions used to generate the targets. The
+            return annotation of the concatenated function reflects the requested return
+            type and number of targets (e.g., for two targets returned as a list, the
+            return annotation is a list of their respective type hints). Note that this
+            is not a valid type annotation and should not be used for type checking. All
+            annotations must be strings; otherwise, a NonStringAnnotationError is
+            raised. To ensure string annotations, enclose them in quotes or use "from
+            __future__ import annotations" at the top of your file. An
+            AnnotationMismatchError is raised if annotations differ between functions.
 
     Returns
     -------
         function: A function that produces targets when called with suitable arguments.
+
+    Raises
+    ------
+        - NonStringAnnotationError: If `set_annotations` is `True` and the type
+            annotations are not strings.
+
+        - AnnotationMismatchError: If `set_annotations` is `True` and there are
+            incompatible annotations in the DAG's components.
 
     """
     # Harmonize and check arguments.
@@ -504,6 +521,11 @@ def create_execution_info(
         dict: Dictionary with functions and their arguments for each node in the DAG.
             The functions are already in topological_sort order.
 
+    Raises
+    ------
+        NonStringAnnotationError: If `verify_annotations` is `True` and the type
+            annotations are not strings.
+
     """
     out = {}
     for node in nx.topological_sort(dag):
@@ -534,16 +556,16 @@ def _create_concatenated_function(
         enforce_signature: If True, the signature of the concatenated function
             is enforced. Otherwise it is only provided for introspection purposes.
             Enforcing the signature has a small runtime overhead.
-        set_annotations (bool): If True, we set the annotations of the concatenated
-            function using the annotations of the functions that are used to generate
-            the targets. Type annotations must be strings, else a
-            NonStringAnnotationError is raised. Either enclose the annotations in quotes
-            or add "from __future__ import annotations" at the top of your file. The
-            return annotation of the concatenated function will be a string, tuple,
-            list, or dict, depending on the return type and the number of targets.
-            Importantly, the return annotation is not a valid type annotation, but
-            designed to communicate as much information on the target types as
-            possible.
+        set_annotations (bool): If True, sets the annotations of the concatenated
+            function based on those of the functions used to generate the targets. The
+            return annotation of the concatenated function reflects the requested return
+            type and number of targets (e.g., for two targets returned as a list, the
+            return annotation is a list of their respective type hints). Note that this
+            is not a valid type annotation and should not be used for type checking. All
+            annotations must be strings; otherwise, a NonStringAnnotationError is
+            raised. To ensure string annotations, enclose them in quotes or use "from
+            __future__ import annotations" at the top of your file. An
+            AnnotationMismatchError is raised if annotations differ between functions.
 
     Returns
     -------
@@ -598,6 +620,11 @@ def get_annotations_from_execution_info(
         - Dictionary with argument names as keys and their expected types in string
           format as values.
         - The expected type of the return value as a string.
+
+    Raises
+    ------
+        AnnotationMismatchError: If there are incompatible annotations in the DAG's
+            components.
 
     """
     types: dict[str, str] = {}

--- a/src/dags/exceptions.py
+++ b/src/dags/exceptions.py
@@ -1,5 +1,7 @@
 """Custom exceptions for the dags library."""
 
+from __future__ import annotations
+
 
 class DagsError(Exception):
     """Base exception for all dags-specific errors."""

--- a/src/dags/exceptions.py
+++ b/src/dags/exceptions.py
@@ -11,6 +11,10 @@ class AnnotationMismatchError(DagsError):
     """Raised when there is a mismatch between annotations."""
 
 
+class NonStringAnnotationError(DagsError):
+    """Raised when a non-string annotation is encountered."""
+
+
 class MissingFunctionsError(DagsError):
     """Raised when required functions are missing from the DAG."""
 

--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import inspect
 import operator

--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -173,5 +173,4 @@ def _create_dict_return_annotation(
 
 def _create_list_return_annotation(tuple_of_types: tuple[str | type, ...]) -> str:
     tuple_of_types_str = [get_str_repr(t) for t in tuple_of_types]
-    union_type = " | ".join(sorted(set(tuple_of_types_str)))
-    return f"list[{union_type}]"
+    return f"[{', '.join(tuple_of_types_str)}]"

--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -173,5 +173,5 @@ def _create_dict_return_annotation(
 
 def _create_list_return_annotation(tuple_of_types: tuple[str | type, ...]) -> str:
     tuple_of_types_str = [get_str_repr(t) for t in tuple_of_types]
-    union_type = " | ".join(set(tuple_of_types_str))
+    union_type = " | ".join(sorted(set(tuple_of_types_str)))
     return f"list[{union_type}]"

--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -46,13 +46,13 @@ def single_output(
 
 @overload
 def dict_output(
-    func: Callable[P, tuple[T, ...]], *, keys: list[str], set_annotations: bool
+    func: Callable[P, tuple[T, ...]], *, keys: list[str], set_annotations: bool = False
 ) -> Callable[P, dict[str, T]]: ...
 
 
 @overload
 def dict_output(
-    *, keys: list[str], set_annotations: bool
+    *, keys: list[str], set_annotations: bool = False
 ) -> Callable[[Callable[P, tuple[T, ...]]], Callable[P, dict[str, T]]]: ...
 
 

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import inspect
 from collections.abc import Callable

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -193,7 +193,7 @@ def rename_arguments(
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
-def rename_arguments(
+def rename_arguments(  # noqa: C901
     func: Callable[P, R] | None = None, *, mapper: dict[str, str] | None = None
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Rename positional and keyword arguments of func.

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -223,7 +223,7 @@ def rename_arguments(  # noqa: C901
                 parameters.append(param)
 
         # annotations do not contain information on partialled arguments, and therefore
-        # must be updated separately.
+        # do not exactly align with the parameters.
         for name, annotation in old_annotations.items():
             if mapper is not None and name in mapper:
                 annotations[mapper[name]] = annotation

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -214,21 +214,25 @@ def rename_arguments(
         old_annotations = get_annotations(func)
 
         parameters: list[inspect.Parameter] = []
-        new_annotations: dict[str, str] = {}
+        annotations: dict[str, str] = {}
         # mapper is assumed not to be None when renaming is desired.
         for name, param in old_parameters.items():
             if mapper is not None and name in mapper:
                 parameters.append(param.replace(name=mapper[name]))
-                new_annotations[mapper[name]] = old_annotations[name]
             else:
                 parameters.append(param)
-                new_annotations[name] = old_annotations[name]
+
+        # annotations do not contain information on partialled arguments, and therefore
+        # must be updated separately.
+        for name, annotation in old_annotations.items():
+            if mapper is not None and name in mapper:
+                annotations[mapper[name]] = annotation
+            else:
+                annotations[name] = annotation
 
         signature = inspect.Signature(
             parameters=parameters, return_annotation=old_signature.return_annotation
         )
-
-        annotations = {"return": old_annotations["return"]} | new_annotations
 
         reverse_mapper: dict[str, str] = (
             {v: k for k, v in mapper.items()} if mapper is not None else {}

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def _create_signature(
     args_types: dict[str, str] | dict[str, type[inspect._empty]],
     kwargs_types: dict[str, str] | dict[str, type[inspect._empty]],
-    return_annotation: type[inspect._empty] | str = inspect.Parameter.empty,
+    return_annotation: Any = inspect.Parameter.empty,
 ) -> inspect.Signature:
     """Create an inspect.Signature object based on args and kwargs.
 
@@ -25,7 +25,7 @@ def _create_signature(
             type is available, mapped to `inspect.Parameter.empty`.
         kwargs_types: The keyword arguments mapped to their types as strings, or if no
             type is available, mapped to `inspect.Parameter.empty`.
-        return_annotation: The return annotation as string, or if no type is available,
+        return_annotation: The return annotation. By default, the return annotation is
             `inspect.Parameter.empty`.
 
     Returns
@@ -58,11 +58,11 @@ def _create_signature(
 def _create_annotations(
     args_types: dict[str, str] | dict[str, type[inspect._empty]],
     kwargs_types: dict[str, str] | dict[str, type[inspect._empty]],
-    return_annotation: type[inspect._empty] | str,
-) -> dict[str, str] | dict[str, type[inspect._empty]]:
+    return_annotation: Any,
+) -> dict[str, str | Any] | dict[str, str | type[inspect._empty]]:
     annotations = args_types | kwargs_types
     if return_annotation is not inspect.Parameter.empty:
-        annotations["return"] = return_annotation  # type: ignore[assignment]
+        annotations["return"] = return_annotation
     return annotations  # type: ignore[return-value]
 
 
@@ -73,7 +73,7 @@ def with_signature(
     args: dict[str, str] | list[str] | None = None,
     kwargs: dict[str, str] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: type[inspect._empty] | str = inspect.Parameter.empty,
+    return_annotation: Any = inspect.Parameter.empty,
 ) -> Callable[P, R]: ...
 
 
@@ -83,7 +83,7 @@ def with_signature(
     args: dict[str, str] | list[str] | None = None,
     kwargs: dict[str, str] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: type[inspect._empty] | str = inspect.Parameter.empty,
+    return_annotation: Any = inspect.Parameter.empty,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
@@ -93,7 +93,7 @@ def with_signature(
     args: dict[str, str] | list[str] | None = None,
     kwargs: dict[str, str] | list[str] | None = None,
     enforce: bool = True,
-    return_annotation: type[inspect._empty] | str = inspect.Parameter.empty,
+    return_annotation: Any = inspect.Parameter.empty,
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Add a signature to a function of type `f(*args, **kwargs)` (decorator).
 
@@ -110,7 +110,8 @@ def with_signature(
         enforce: Whether the signature should be enforced or just
             added to the function for introspection. This creates runtime
             overhead.
-        return_annotation: The return annotation as string.
+        return_annotation: The return annotation. By default, the return annotation is
+            `inspect.Parameter.empty`.
 
     Returns
     -------

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -1,4 +1,5 @@
 """Module for handling DAG trees with nested dictionaries and qualified names."""
+from __future__ import annotations
 
 from dags.tree.dag_tree import (
     concatenate_functions_tree,

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dags.tree.dag_tree import (
     concatenate_functions_tree,
     create_dag_tree,
-    create_input_structure_tree,
+    create_input_types_tree,
     functions_without_tree_logic,
     one_function_without_tree_logic,
 )
@@ -33,7 +33,7 @@ from dags.tree.validation import (
 
 __all__ = [
     # Primary functions
-    "create_input_structure_tree",
+    "create_input_types_tree",
     "create_dag_tree",
     "concatenate_functions_tree",
     "functions_without_tree_logic",

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dags.tree.dag_tree import (
     concatenate_functions_tree,
     create_dag_tree,
-    create_input_types_tree,
+    create_tree_with_input_types,
     functions_without_tree_logic,
     one_function_without_tree_logic,
 )
@@ -33,7 +33,7 @@ from dags.tree.validation import (
 
 __all__ = [
     # Primary functions
-    "create_input_types_tree",
+    "create_tree_with_input_types",
     "create_dag_tree",
     "concatenate_functions_tree",
     "functions_without_tree_logic",

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -1,4 +1,5 @@
 """Module for handling DAG trees with nested dictionaries and qualified names."""
+
 from __future__ import annotations
 
 from dags.tree.dag_tree import (

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -129,7 +129,7 @@ def concatenate_functions_tree(
     inputs: NestedInputDict,
     targets: NestedTargetDict | None,
     enforce_signature: bool = True,
-) -> tuple[Callable[[NestedInputDict], NestedOutputDict], NestedInputStructureDict]:
+) -> Callable[[NestedInputDict], NestedOutputDict]:
     """Combine a nested dictionary of functions into a single callable.
 
     Args:

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     )
 
 
-def create_input_types_tree(
+def create_tree_with_input_types(
     functions: NestedFunctionDict,
     targets: NestedTargetDict | None = None,
     top_level_inputs: set[str] | list[str] | tuple[str, ...] = (),

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     )
 
 
-def create_input_structure_tree(
+def create_input_types_tree(
     functions: NestedFunctionDict,
     targets: NestedTargetDict | None = None,
     top_level_inputs: set[str] | list[str] | tuple[str, ...] = (),

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -9,8 +9,8 @@ from dags.dag import (
     concatenate_functions,
     create_arguments_of_concatenated_function,
     create_dag,
+    get_annotations,
     get_free_arguments,
-    get_input_types,
 )
 from dags.signature import rename_arguments
 from dags.tree.tree_utils import (
@@ -158,7 +158,7 @@ def concatenate_functions_tree(
         qual_name_outputs = concatenated_function(**qual_name_inputs)
         return unflatten_from_qual_names(qual_name_outputs)
 
-    input_types_flat = get_input_types(concatenated_function)
+    input_types_flat = get_annotations(concatenated_function)
     input_types_empty_replaced = {
         k: _mark_unavailable_if_empty(v) for k, v in input_types_flat.items()
     }

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import TYPE_CHECKING
 
 from dags.dag import (
     concatenate_functions,
     create_arguments_of_concatenated_function,
     create_dag,
+    create_execution_info,
+    get_annotations_from_execution_info,
     get_free_arguments,
+    harmonize_and_check_functions_and_targets,
 )
 from dags.signature import rename_arguments
 from dags.tree.tree_utils import (
@@ -72,14 +74,25 @@ def create_input_structure_tree(
         top_level_namespace=top_level_namespace,
     )
 
-    parameters = create_arguments_of_concatenated_function(
+    targets_qual_names = qual_names(targets) if targets is not None else None
+
+    _functions, _targets = harmonize_and_check_functions_and_targets(
         functions=functions_for_flat_dags,
-        dag=create_dag(
-            functions=functions_for_flat_dags,
-            targets=qual_names(targets) if targets is not None else None,
-        ),
+        targets=targets_qual_names,
     )
-    return unflatten_from_qual_names(dict.fromkeys(parameters))
+
+    dag = create_dag(
+        functions=_functions,
+        targets=_targets,
+    )
+    arglist = create_arguments_of_concatenated_function(functions=_functions, dag=dag)
+    execution_info = create_execution_info(_functions, dag)
+    args = get_annotations_from_execution_info(
+        execution_info,
+        arglist=arglist,
+        targets=_targets,
+    )[0]
+    return unflatten_from_qual_names(args)
 
 
 def create_dag_tree(
@@ -152,12 +165,6 @@ def concatenate_functions_tree(
         return unflatten_from_qual_names(qual_name_outputs)
 
     return wrapper
-
-
-def _mark_unavailable_if_empty(value: type) -> str | type:
-    if value is inspect.Parameter.empty:
-        return "unavailable_type"
-    return value
 
 
 def functions_without_tree_logic(

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -132,7 +132,8 @@ def concatenate_functions_tree(
 
     Returns
     -------
-        A callable that takes a NestedInputDict and returns a NestedOutputDict.
+        - A callable that takes a NestedInputDict and returns a NestedOutputDict.
+        - A NestedInputStructureDict that describes the structure of the inputs.
     """
     top_level_namespace = _get_top_level_namespace_final(
         functions=functions,

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -159,25 +159,26 @@ def functions_without_tree_logic(
     functions: NestedFunctionDict,
     top_level_namespace: set[str],
 ) -> QualNameFunctionDict:
-    """Return a functions dictionary that `dags.concatenate` functions can work with.
+    """Return a functions dictionary that `dags.concatenate_functions` can work with.
 
     In particular, remove all tree logic by
-    1. Flattening the set of functions and inputs to qualified absolute names
-    2. Convert all functions so they will only take qualified absolute names as
-       arguments.
 
-    The result can be put into `dags.dag.concatenate_functions`.
+    1. Flattening the set of functions and inputs to qualified absolute names.
+    2. Convert all functions so they take only qualified absolute names as arguments.
+
+    The result can be put into `dags.concatenate_functions`.
 
     Args:
-        functions: A nested dictionary of functions. input_structure: A nested
-        dictionary describing the input structure. top_level_namespace: The elements of
-        or not.
+        functions:
+            A nested dictionary of functions.
+        top_level_namespace:
+            The elements of the top-level namespace.
 
 
     Returns
     -------
-        A flat dictionary mapping qualified absolute names to functions taking
-        qualified absolute names as arguments.
+    A flat dictionary mapping qualified absolute names to functions taking qualified
+    absolute names as arguments.
 
     """
     tree_path_functions = flatten_to_tree_paths(functions)

--- a/src/dags/tree/exceptions.py
+++ b/src/dags/tree/exceptions.py
@@ -1,4 +1,5 @@
 """Custom exceptions for the dags library."""
+
 from __future__ import annotations
 
 from dags.exceptions import ValidationError

--- a/src/dags/tree/exceptions.py
+++ b/src/dags/tree/exceptions.py
@@ -1,4 +1,5 @@
 """Custom exceptions for the dags library."""
+from __future__ import annotations
 
 from dags.exceptions import ValidationError
 

--- a/src/dags/tree/typing.py
+++ b/src/dags/tree/typing.py
@@ -27,10 +27,10 @@ QualNameFunctionDict = dict[str, GenericCallable]
 TreePathFunctionDict = dict[tuple[str, ...], GenericCallable]
 
 # Input structure types
-NestedInputStructureDict = Mapping[str, "None | NestedInputStructureDict"]
-QualNameInputStructureDict = dict[str, None]
-TreePathInputStructureDict = dict[tuple[str, ...], None]
+NestedInputStructureDict = Mapping[str, "str | None | NestedInputStructureDict"]
+QualNameInputStructureDict = dict[str, "str | None"]
+TreePathInputStructureDict = dict[tuple[str, ...], "str | None"]
 
 # Target types
-NestedTargetDict = Mapping[str, "None | NestedTargetDict"]
+NestedTargetDict = Mapping[str, "str | None | NestedTargetDict"]
 QualNameTargetList = list[str]

--- a/src/dags/typing.py
+++ b/src/dags/typing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from typing import Any, Literal, ParamSpec, TypeVar
 

--- a/src/dags/typing.py
+++ b/src/dags/typing.py
@@ -19,4 +19,4 @@ R = TypeVar("R")
 # Generic type variable for use in type constructors
 T = TypeVar("T")
 # Variadic TypeVar for tuples of arbitrary length with heterogeneous element types
-HetTupleType = TypeVarTuple("HetTupleType")
+MixedTupleType = TypeVarTuple("MixedTupleType")

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from dags.dag import concatenate_functions

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -97,6 +97,7 @@ def test_get_annotations_with_default() -> None:
     def f(a) -> float:  # type: ignore[no-untyped-def]
         return float(a)
 
+    assert get_annotations(f) == {"a": "no_annotation_found", "return": "float"}
     assert get_annotations(f, default="default") == {"a": "default", "return": "float"}
     assert get_annotations(f, default=bool, eval_str=True) == {
         "a": bool,

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -4,7 +4,9 @@ import functools
 import inspect
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 from dags.annotations import get_annotations, verify_annotations_are_strings
 from dags.dag import concatenate_functions
@@ -98,6 +100,17 @@ def test_get_annotations_with_default() -> None:
     assert get_annotations(f, default="default") == {"a": "default", "return": "float"}
     assert get_annotations(f, default=bool, eval_str=True) == {
         "a": bool,
+        "return": float,
+    }
+
+
+def test_get_annotations_with_numpy() -> None:
+    def f(a: NDArray[np.float64]) -> float:
+        return a.sum()
+
+    assert get_annotations(f) == {"a": "NDArray[np.float64]", "return": "float"}
+    assert get_annotations(f, eval_str=True) == {
+        "a": NDArray[np.float64],
         "return": float,
     }
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -4,8 +4,8 @@ import functools
 
 import pytest
 
-from dags.annotations import get_annotations
-from dags.dag import _verify_annotations_are_strings, concatenate_functions
+from dags.annotations import get_annotations, verify_annotations_are_strings
+from dags.dag import concatenate_functions
 from dags.exceptions import AnnotationMismatchError, NonStringAnnotationError
 
 
@@ -78,7 +78,7 @@ def test_get_annotations_with_default() -> None:
 
 
 def test_verify_annotations_are_strings() -> None:
-    _verify_annotations_are_strings({"a": "int", "return": "float"}, "f")
+    verify_annotations_are_strings({"a": "int", "return": "float"}, "f")
 
 
 def test_verify_annotations_are_strings_non_string_argument_full_message() -> None:
@@ -94,7 +94,7 @@ def test_verify_annotations_are_strings_non_string_argument_full_message() -> No
             r"\tf\(a: 'int'\) -> 'float'\."
         ),
     ):
-        _verify_annotations_are_strings({"a": int, "return": "float"}, "f")  # type: ignore[dict-item]
+        verify_annotations_are_strings({"a": int, "return": "float"}, "f")  # type: ignore[dict-item]
 
 
 def test_verify_annotations_are_strings_multiple_non_string_argument() -> None:
@@ -105,7 +105,7 @@ def test_verify_annotations_are_strings_multiple_non_string_argument() -> None:
             r"arguments \(a, b\) are not strings."
         ),
     ):
-        _verify_annotations_are_strings({"a": int, "b": bool, "return": "float"}, "f")  # type: ignore[dict-item]
+        verify_annotations_are_strings({"a": int, "b": bool, "return": "float"}, "f")  # type: ignore[dict-item]
 
 
 def test_verify_annotations_are_strings_non_string_return() -> None:
@@ -116,7 +116,7 @@ def test_verify_annotations_are_strings_non_string_return() -> None:
             " value are not strings."
         ),
     ):
-        _verify_annotations_are_strings({"a": "int", "return": float}, "f")  # type: ignore[dict-item]
+        verify_annotations_are_strings({"a": "int", "return": float}, "f")  # type: ignore[dict-item]
 
 
 def test_verify_annotations_are_strings_non_string_argument_and_return() -> None:
@@ -127,4 +127,4 @@ def test_verify_annotations_are_strings_non_string_argument_and_return() -> None
             r" \(a\) and the return value are not strings."
         ),
     ):
-        _verify_annotations_are_strings({"a": int, "return": float}, "f")  # type: ignore[dict-item]
+        verify_annotations_are_strings({"a": int, "return": float}, "f")  # type: ignore[dict-item]

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -175,29 +175,40 @@ def test_concatenate_functions_multi_target_signature_and_annotations(
         set_annotations=True,
     )
 
+    expected_functions: dict[str, GenericCallable] = {}
+
     if return_type == "tuple":
 
-        def expected(
+        def expected_tuple(  # type: ignore[empty-body]
             working_hours: int, wage: float, leisure_weight: float
         ) -> tuple[float, float]:
             pass
+
+        expected_functions["tuple"] = expected_tuple
+
     elif return_type == "list":
 
-        def expected(
+        def expected_list(  # type: ignore[empty-body]
             working_hours: int, wage: float, leisure_weight: float
         ) -> list[float]:
             pass
+
+        expected_functions["list"] = expected_list
     elif return_type == "dict":
 
-        def expected(
+        def expected_dict(  # type: ignore[empty-body]
             working_hours: int, wage: float, leisure_weight: float
-        ) -> {"_utility": float, "_consumption": float}:  # type: ignore[valid-type]  # noqa: UP037
+        ) -> {"_utility": float, "_consumption": float}:  # noqa: UP037
             pass
 
-    assert inspect.signature(expected) == inspect.signature(concatenated)
-    assert inspect.get_annotations(expected, eval_str=True) == inspect.get_annotations(
-        concatenated, eval_str=True
+        expected_functions["dict"] = expected_dict
+
+    assert inspect.signature(expected_functions[return_type]) == inspect.signature(
+        concatenated
     )
+    assert inspect.get_annotations(
+        expected_functions[return_type], eval_str=True
+    ) == inspect.get_annotations(concatenated, eval_str=True)
 
 
 def test_get_ancestors_many_ancestors() -> None:

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -13,7 +13,7 @@ from dags.dag import (
     get_ancestors,
     get_annotations,
 )
-from dags.exceptions import CyclicDependencyError
+from dags.exceptions import CyclicDependencyError, DagsError
 
 if TYPE_CHECKING:
     from dags.typing import (
@@ -345,3 +345,13 @@ def test_get_str_repr() -> None:
     assert get_str_repr("int") == "int"
     assert get_str_repr(int) == "int"
     assert get_str_repr(1) == "1"
+
+
+def test_concatenate_functions_with_aggregator_and_multiple_targets() -> None:
+    with pytest.raises(DagsError):
+        concatenate_functions(
+            functions={},
+            targets=["f1", "f2"],
+            aggregator=lambda a, b: a + b,
+            set_annotations=True,
+        )

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -198,7 +198,7 @@ def test_concatenate_functions_multi_target_signature_and_annotations(
 
         def expected_dict(  # type: ignore[empty-body]
             working_hours: int, wage: float, leisure_weight: float
-        ) -> {"_utility": float, "_consumption": float}:  # noqa: UP037
+        ) -> {"_utility": float, "_consumption": float}:  # type: ignore[misc]  # noqa: UP037
             pass
 
         expected_functions["dict"] = expected_dict

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -9,6 +9,7 @@ from dags.dag import (
     concatenate_functions,
     create_dag,
     get_ancestors,
+    get_input_types,
 )
 from dags.exceptions import CyclicDependencyError
 from dags.typing import (
@@ -274,4 +275,23 @@ def test_get_annotations_from_func() -> None:
 
     got = _get_annotations_from_func(f, free_arguments=["a", "b"])
     exp = {"a": int, "b": float}, float
+    assert got == exp
+
+
+def test_get_input_types() -> None:
+    def f(a: int, b: float) -> float:
+        return 1.0
+
+    got = get_input_types(f)
+    exp = {"a": int, "b": float}
+    assert got == exp
+
+
+def test_get_input_types_partial() -> None:
+    def f(a: int, b: float) -> float:
+        return 1.0
+
+    partial_f = partial(f, a=1)
+    got = get_input_types(partial_f)
+    exp = {"b": float}
     assert got == exp

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -374,3 +374,23 @@ def test_function_execution_info() -> None:
     assert info.annotations == {"a": "int", "b": "float", "return": "float"}
     assert info.argument_annotations == {"a": "int", "b": "float"}
     assert info.return_annotation == "float"
+
+
+def test_concatenate_functions_no_annotations_set_annotations() -> None:
+    def f(a):
+        return a
+
+    concatenated = concatenate_functions(
+        functions=[f],
+        targets=None,
+        set_annotations=True,
+    )
+
+    assert inspect.get_annotations(concatenated) == {
+        "a": "None",
+        "return": "tuple['None']",
+    }
+    assert inspect.get_annotations(concatenated, eval_str=True) == {
+        "a": None,
+        "return": tuple["None"],
+    }

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -190,9 +190,9 @@ def test_concatenate_functions_multi_target_signature_and_annotations(
 
     elif return_type == "list":
 
-        def expected_list(  # type: ignore[empty-body]
+        def expected_list(
             working_hours: int, wage: float, leisure_weight: float
-        ) -> list[float]:
+        ) -> [float, float]:  # type: ignore[valid-type]
             pass
 
         expected_functions["list"] = expected_list

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from dags.annotations import get_str_repr
 from dags.dag import (
-    _get_object_name,
     concatenate_functions,
     create_dag,
     get_ancestors,
@@ -341,7 +341,7 @@ def test_get_annotations_partial_eval_str() -> None:
     assert got == exp
 
 
-def test_get_object_name() -> None:
-    assert _get_object_name("int") == "int"
-    assert _get_object_name(int) == "int"
-    assert _get_object_name(1) == "1"
+def test_get_str_repr() -> None:
+    assert get_str_repr("int") == "int"
+    assert get_str_repr(int) == "int"
+    assert get_str_repr(1) == "1"

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 from functools import partial
 from typing import TypedDict, get_type_hints

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -295,7 +295,16 @@ def test_get_annotations() -> None:
     def f(a: int, b: float) -> float:
         return 1.0
 
-    got = get_annotations(f)
+    got = get_annotations(f, eval_str=False)
+    exp = {"a": "int", "b": "float", "return": "float"}
+    assert got == exp
+
+
+def test_get_annotations_eval_str() -> None:
+    def f(a: int, b: float) -> float:
+        return 1.0
+
+    got = get_annotations(f, eval_str=True)
     exp = {"a": int, "b": float, "return": float}
     assert got == exp
 
@@ -305,6 +314,16 @@ def test_get_annotations_partial() -> None:
         return 1.0
 
     partial_f = partial(f, a=1)
-    got = get_annotations(partial_f)
+    got = get_annotations(partial_f, eval_str=False)
+    exp = {"b": "float", "return": "float"}
+    assert got == exp
+
+
+def test_get_annotations_partial_eval_str() -> None:
+    def f(a: int, b: float) -> float:
+        return 1.0
+
+    partial_f = partial(f, a=1)
+    got = get_annotations(partial_f, eval_str=True)
     exp = {"b": float, "return": float}
     assert got == exp

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -7,11 +7,10 @@ from typing import TypedDict, get_type_hints
 import pytest
 
 from dags.dag import (
-    _get_annotations_from_func,
     concatenate_functions,
     create_dag,
     get_ancestors,
-    get_input_types,
+    get_annotations,
 )
 from dags.exceptions import CyclicDependencyError
 from dags.typing import (
@@ -271,29 +270,20 @@ def test_fail_if_cycle_in_dag(funcs: FunctionCollection) -> None:
         create_dag(functions=funcs, targets=["_utility"])
 
 
-def test_get_annotations_from_func() -> None:
-    def f(a: int, b: float, c: bool) -> float:
-        return 1.0
-
-    got = _get_annotations_from_func(f, free_arguments=["a", "b"])
-    exp = {"a": int, "b": float}, float
-    assert got == exp
-
-
-def test_get_input_types() -> None:
+def test_get_annotations() -> None:
     def f(a: int, b: float) -> float:
         return 1.0
 
-    got = get_input_types(f)
-    exp = {"a": int, "b": float}
+    got = get_annotations(f)
+    exp = {"a": int, "b": float, "return": float}
     assert got == exp
 
 
-def test_get_input_types_partial() -> None:
+def test_get_annotations_partial() -> None:
     def f(a: int, b: float) -> float:
         return 1.0
 
     partial_f = partial(f, a=1)
-    got = get_input_types(partial_f)
-    exp = {"b": float}
+    got = get_annotations(partial_f)
+    exp = {"b": float, "return": float}
     assert got == exp

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from dags.dag import (
+    _get_object_name,
     concatenate_functions,
     create_dag,
     get_ancestors,
@@ -338,3 +339,9 @@ def test_get_annotations_partial_eval_str() -> None:
     got = get_annotations(partial_f, eval_str=True)
     exp = {"b": float, "return": float}
     assert got == exp
+
+
+def test_get_object_name() -> None:
+    assert _get_object_name("int") == "int"
+    assert _get_object_name(int) == "int"
+    assert _get_object_name(1) == "1"

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -8,6 +8,7 @@ import pytest
 
 from dags.annotations import get_str_repr
 from dags.dag import (
+    FunctionExecutionInfo,
     concatenate_functions,
     create_dag,
     get_ancestors,
@@ -355,3 +356,21 @@ def test_concatenate_functions_with_aggregator_and_multiple_targets() -> None:
             aggregator=lambda a, b: a + b,
             set_annotations=True,
         )
+
+
+def test_function_execution_info() -> None:
+    def f(a: int, b: float) -> float:
+        return a + b
+
+    info = FunctionExecutionInfo(
+        name="f",
+        func=f,
+        verify_annotations=True,
+    )
+
+    assert info.name == "f"
+    assert info.func == f
+    assert info.verify_annotations is True
+    assert info.annotations == {"a": "int", "b": "float", "return": "float"}
+    assert info.argument_annotations == {"a": "int", "b": "float"}
+    assert info.return_annotation == "float"

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def f(g: int, a: int, b: float, c) -> float:  # type: ignore[no-untyped-def]
-    # We expect to see "no_annotation_found" for c, because it is not annotated.
+    # We expect to see "None" for c, because it is not annotated.
     return g + a + b + c
 
 
@@ -63,7 +63,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "no_annotation_found",
+                    "c": "None",
                 },
                 "n2": {
                     "a": "int",
@@ -78,7 +78,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "no_annotation_found",
+                    "c": "None",
                 },
                 "n2": {
                     "b": {"g": "int"},
@@ -92,7 +92,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "no_annotation_found",
+                    "c": "None",
                 },
             },
         ),
@@ -103,7 +103,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "no_annotation_found",
+                    "c": "None",
                 },
             },
         ),
@@ -140,7 +140,7 @@ def test_create_input_structure_tree_simple(
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "no_annotation_found",
+                    "c": "None",
                 },
                 "n2": {
                     "a": "int",
@@ -155,7 +155,7 @@ def test_create_input_structure_tree_simple(
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "no_annotation_found",
+                    "c": "None",
                 },
             },
         ),
@@ -193,6 +193,4 @@ def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
         },
         targets=None,
         top_level_inputs=set(),
-    ) == {
-        "n1": {"a": {"a": "int", "b": "float", "g": "int", "c": "no_annotation_found"}}
-    }
+    ) == {"n1": {"a": {"a": "int", "b": "float", "g": "int", "c": "None"}}}

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from dags.tree import RepeatedTopLevelElementError, create_input_structure_tree
+from dags.tree import RepeatedTopLevelElementError, create_input_types_tree
 
 if TYPE_CHECKING:
     from dags.tree.typing import (
@@ -122,10 +122,10 @@ def test_create_input_structure_tree_simple(
 ) -> None:
     if "raises_error" in expected:
         with pytest.raises(RepeatedTopLevelElementError):
-            create_input_structure_tree(functions_simple, targets, top_level_inputs)
+            create_input_types_tree(functions_simple, targets, top_level_inputs)
     else:
         assert (
-            create_input_structure_tree(functions_simple, targets, top_level_inputs)
+            create_input_types_tree(functions_simple, targets, top_level_inputs)
             == expected
         )
 
@@ -174,12 +174,12 @@ def test_create_input_structure_tree_nested_and_duplicate_g(
 ) -> None:
     if "raises_error" in expected:
         with pytest.raises(RepeatedTopLevelElementError):
-            create_input_structure_tree(
+            create_input_types_tree(
                 functions_nested_and_duplicate_g, targets, top_level_inputs
             )
     else:
         assert (
-            create_input_structure_tree(
+            create_input_types_tree(
                 functions_nested_and_duplicate_g, targets, top_level_inputs
             )
             == expected
@@ -187,7 +187,7 @@ def test_create_input_structure_tree_nested_and_duplicate_g(
 
 
 def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
-    assert create_input_structure_tree(
+    assert create_input_types_tree(
         functions={
             "n1": {"a": {"f": f}},
         },

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def f(g: int, a: int, b: float, c) -> float:  # type: ignore[no-untyped-def]
-    # We expect to see "unknown_type" for c, because it is not annotated.
+    # We expect to see "no_annotation_found" for c, because it is not annotated.
     return g + a + b + c
 
 
@@ -63,7 +63,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "unknown_type",
+                    "c": "no_annotation_found",
                 },
                 "n2": {
                     "a": "int",
@@ -78,7 +78,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "unknown_type",
+                    "c": "no_annotation_found",
                 },
                 "n2": {
                     "b": {"g": "int"},
@@ -92,7 +92,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "unknown_type",
+                    "c": "no_annotation_found",
                 },
             },
         ),
@@ -103,7 +103,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "unknown_type",
+                    "c": "no_annotation_found",
                 },
             },
         ),
@@ -140,7 +140,7 @@ def test_create_input_structure_tree_simple(
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "unknown_type",
+                    "c": "no_annotation_found",
                 },
                 "n2": {
                     "a": "int",
@@ -155,7 +155,7 @@ def test_create_input_structure_tree_simple(
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "unknown_type",
+                    "c": "no_annotation_found",
                 },
             },
         ),
@@ -193,4 +193,6 @@ def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
         },
         targets=None,
         top_level_inputs=set(),
-    ) == {"n1": {"a": {"a": "int", "b": "float", "g": "int", "c": "unknown_type"}}}
+    ) == {
+        "n1": {"a": {"a": "int", "b": "float", "g": "int", "c": "no_annotation_found"}}
+    }

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -187,3 +187,20 @@ def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
         targets=None,
         top_level_inputs=set(),
     ) == {"n1": {"a": {"a": None, "b": None, "g": None}}}
+
+
+def test_partialled_function_input_types() -> None:
+    def f(a: int, b: float) -> float:
+        return a + b
+
+    tree = {"f": f}
+    input_structure = {"a": None, "b": None}
+    targets = {"f": None}
+
+    input_types = concatenate_functions_tree(
+        functions=tree,
+        targets=targets,
+        inputs=input_structure,
+        enforce_signature=True,
+    )
+    assert input_types == {"a": int, "b": float}

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def f(g: int, a: int, b: float, c) -> float:  # type: ignore[no-untyped-def]
-    # We expect to see "None" for c, because it is not annotated.
+    # We expect to see "no_annotation_found" for c, because it is not annotated.
     return g + a + b + c
 
 
@@ -63,7 +63,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "None",
+                    "c": "no_annotation_found",
                 },
                 "n2": {
                     "a": "int",
@@ -78,7 +78,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "None",
+                    "c": "no_annotation_found",
                 },
                 "n2": {
                     "b": {"g": "int"},
@@ -92,7 +92,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "None",
+                    "c": "no_annotation_found",
                 },
             },
         ),
@@ -103,7 +103,7 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "None",
+                    "c": "no_annotation_found",
                 },
             },
         ),
@@ -140,7 +140,7 @@ def test_create_input_structure_tree_simple(
                 "n1": {
                     "a": "int",
                     "b": "float",
-                    "c": "None",
+                    "c": "no_annotation_found",
                 },
                 "n2": {
                     "a": "int",
@@ -155,7 +155,7 @@ def test_create_input_structure_tree_simple(
                 "a": "int",
                 "n1": {
                     "b": "float",
-                    "c": "None",
+                    "c": "no_annotation_found",
                 },
             },
         ),
@@ -193,4 +193,6 @@ def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
         },
         targets=None,
         top_level_inputs=set(),
-    ) == {"n1": {"a": {"a": "int", "b": "float", "g": "int", "c": "None"}}}
+    ) == {
+        "n1": {"a": {"a": "int", "b": "float", "g": "int", "c": "no_annotation_found"}}
+    }

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
     )
 
 
-def f(g: int, a: int, b: float, c) -> float:
-    # We expect to see "unknown_type" for c
+def f(g: int, a: int, b: float, c) -> float:  # type: ignore[no-untyped-def]
+    # We expect to see "unknown_type" for c, because it is not annotated.
     return g + a + b + c
 
 

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -16,15 +16,16 @@ if TYPE_CHECKING:
     )
 
 
-def f(g, a, b):
-    return g + a + b
+def f(g: int, a: int, b: float, c) -> float:
+    # We expect to see "unknown_type" for c
+    return g + a + b + c
 
 
-def g(a):
+def g(a: int) -> int:
     return a**2
 
 
-def h(a, b__g):
+def h(a: int, b__g: int) -> int:
     return a + b__g
 
 
@@ -60,12 +61,13 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
             set(),
             {
                 "n1": {
-                    "a": None,
-                    "b": None,
+                    "a": "int",
+                    "b": "float",
+                    "c": "unknown_type",
                 },
                 "n2": {
-                    "a": None,
-                    "b": {"g": None},
+                    "a": "int",
+                    "b": {"g": "int"},
                 },
             },
         ),
@@ -73,32 +75,35 @@ def functions_nested_and_duplicate_g() -> NestedFunctionDict:
             None,
             {"a"},
             {
-                "a": None,
+                "a": "int",
                 "n1": {
-                    "b": None,
+                    "b": "float",
+                    "c": "unknown_type",
                 },
                 "n2": {
-                    "b": {"g": None},
+                    "b": {"g": "int"},
                 },
             },
         ),
         (
-            {"n1": {"f": None}},
+            {"n1": {"f": "float"}},
             set(),
             {
                 "n1": {
-                    "a": None,
-                    "b": None,
+                    "a": "int",
+                    "b": "float",
+                    "c": "unknown_type",
                 },
             },
         ),
         (
-            {"n1": {"f": None}},
+            {"n1": {"f": "float"}},
             {"a"},
             {
-                "a": None,
+                "a": "int",
                 "n1": {
-                    "b": None,
+                    "b": "float",
+                    "c": "unknown_type",
                 },
             },
         ),
@@ -133,12 +138,13 @@ def test_create_input_structure_tree_simple(
             set(),
             {
                 "n1": {
-                    "a": None,
-                    "b": None,
+                    "a": "int",
+                    "b": "float",
+                    "c": "unknown_type",
                 },
                 "n2": {
-                    "a": None,
-                    "b": {"a": None},
+                    "a": "int",
+                    "b": {"a": "int"},
                 },
             },
         ),
@@ -146,9 +152,10 @@ def test_create_input_structure_tree_simple(
             None,
             {"a"},
             {
-                "a": None,
+                "a": "int",
                 "n1": {
-                    "b": None,
+                    "b": "float",
+                    "c": "unknown_type",
                 },
             },
         ),
@@ -186,4 +193,4 @@ def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
         },
         targets=None,
         top_level_inputs=set(),
-    ) == {"n1": {"a": {"a": None, "b": None, "g": None}}}
+    ) == {"n1": {"a": {"a": "int", "b": "float", "g": "int", "c": "unknown_type"}}}

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -187,20 +187,3 @@ def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
         targets=None,
         top_level_inputs=set(),
     ) == {"n1": {"a": {"a": None, "b": None, "g": None}}}
-
-
-def test_partialled_function_input_types() -> None:
-    def f(a: int, b: float) -> float:
-        return a + b
-
-    tree = {"f": f}
-    input_structure = {"a": None, "b": None}
-    targets = {"f": None}
-
-    input_types = concatenate_functions_tree(
-        functions=tree,
-        targets=targets,
-        inputs=input_structure,
-        enforce_signature=True,
-    )
-    assert input_types == {"a": int, "b": float}

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from dags.tree import RepeatedTopLevelElementError, create_input_types_tree
+from dags.tree import RepeatedTopLevelElementError, create_tree_with_input_types
 
 if TYPE_CHECKING:
     from dags.tree.typing import (
@@ -122,10 +122,10 @@ def test_create_input_structure_tree_simple(
 ) -> None:
     if "raises_error" in expected:
         with pytest.raises(RepeatedTopLevelElementError):
-            create_input_types_tree(functions_simple, targets, top_level_inputs)
+            create_tree_with_input_types(functions_simple, targets, top_level_inputs)
     else:
         assert (
-            create_input_types_tree(functions_simple, targets, top_level_inputs)
+            create_tree_with_input_types(functions_simple, targets, top_level_inputs)
             == expected
         )
 
@@ -174,12 +174,12 @@ def test_create_input_structure_tree_nested_and_duplicate_g(
 ) -> None:
     if "raises_error" in expected:
         with pytest.raises(RepeatedTopLevelElementError):
-            create_input_types_tree(
+            create_tree_with_input_types(
                 functions_nested_and_duplicate_g, targets, top_level_inputs
             )
     else:
         assert (
-            create_input_types_tree(
+            create_tree_with_input_types(
                 functions_nested_and_duplicate_g, targets, top_level_inputs
             )
             == expected
@@ -187,7 +187,7 @@ def test_create_input_structure_tree_nested_and_duplicate_g(
 
 
 def test_create_input_structure_tree_duplicates_lower_in_hierarchy() -> None:
-    assert create_input_types_tree(
+    assert create_tree_with_input_types(
         functions={
             "n1": {"a": {"f": f}},
         },

--- a/tests/test_dag_tree/test_dag_tree.py
+++ b/tests/test_dag_tree/test_dag_tree.py
@@ -1,34 +1,29 @@
 """Tests for the dag_tree module."""
 
-from __future__ import annotations
-
 import functools
-from typing import TYPE_CHECKING
 
 import pytest
 
 from dags.tree import (
     concatenate_functions_tree,
 )
-
-if TYPE_CHECKING:
-    from dags.tree.typing import (
-        NestedFunctionDict,
-        NestedInputDict,
-        NestedOutputDict,
-        NestedTargetDict,
-    )
+from dags.tree.typing import (
+    NestedFunctionDict,
+    NestedInputDict,
+    NestedOutputDict,
+    NestedTargetDict,
+)
 
 
-def f(g, a, b):
+def f(g: int, a: int, b: float) -> float:
     return g + a + b
 
 
-def g(a):
+def g(a: int) -> int:
     return a**2
 
 
-def h(a, b__g):
+def h(a: int, b__g: int) -> int:
     return a + b__g
 
 
@@ -119,7 +114,7 @@ def test_concatenate_functions_tree_simple(
         inputs=input_data,
         targets=targets,
         enforce_signature=True,
-    )
+    )[0]
     assert f(input_data) == expected
 
 
@@ -163,7 +158,7 @@ def test_concatenate_functions_tree_nested_and_duplicate_g(
         targets=targets,
         inputs=input_data,
         enforce_signature=True,
-    )
+    )[0]
     assert f(input_data) == expected
 
 
@@ -181,5 +176,23 @@ def test_partialled_function_argument() -> None:
         targets=targets,
         inputs=input_structure,
         enforce_signature=True,
-    )
+    )[0]
     concatenated_func({"a": 1})
+
+
+def test_partialled_function_input_types() -> None:
+    def f(a: int, b: float) -> float:
+        return a + b
+
+    tree = {"f": f}
+    input_structure = {"a": None, "b": None}
+    targets = {"f": None}
+
+    input_types = concatenate_functions_tree(
+        functions=tree,
+        targets=targets,
+        inputs=input_structure,
+        enforce_signature=True,
+        set_annotations=True,
+    )[1]
+    assert input_types == {"a": int, "b": float}

--- a/tests/test_dag_tree/test_dag_tree.py
+++ b/tests/test_dag_tree/test_dag_tree.py
@@ -1,5 +1,7 @@
 """Tests for the dag_tree module."""
 
+from __future__ import annotations
+
 import functools
 
 import pytest

--- a/tests/test_dag_tree/test_dag_tree.py
+++ b/tests/test_dag_tree/test_dag_tree.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 import functools
+from typing import TYPE_CHECKING
 
 import pytest
 
-from dags.tree import (
-    concatenate_functions_tree,
-)
-from dags.tree.typing import (
-    NestedFunctionDict,
-    NestedInputDict,
-    NestedOutputDict,
-    NestedTargetDict,
-)
+from dags.tree import concatenate_functions_tree
+
+if TYPE_CHECKING:
+    from dags.tree.typing import (
+        NestedFunctionDict,
+        NestedInputDict,
+        NestedOutputDict,
+        NestedTargetDict,
+    )
 
 
 def f(g: int, a: int, b: float) -> float:
@@ -116,7 +117,7 @@ def test_concatenate_functions_tree_simple(
         inputs=input_data,
         targets=targets,
         enforce_signature=True,
-    )[0]
+    )
     assert f(input_data) == expected
 
 
@@ -160,7 +161,7 @@ def test_concatenate_functions_tree_nested_and_duplicate_g(
         targets=targets,
         inputs=input_data,
         enforce_signature=True,
-    )[0]
+    )
     assert f(input_data) == expected
 
 
@@ -178,23 +179,5 @@ def test_partialled_function_argument() -> None:
         targets=targets,
         inputs=input_structure,
         enforce_signature=True,
-    )[0]
-    concatenated_func({"a": 1})
-
-
-def test_partialled_function_input_types() -> None:
-    def f(a: int, b: float) -> float:
-        return a + b
-
-    tree = {"f": f}
-    input_structure = {"a": None, "b": None}
-    targets = {"f": None}
-
-    input_types = concatenate_functions_tree(
-        functions=tree,
-        targets=targets,
-        inputs=input_structure,
-        enforce_signature=True,
-        set_annotations=True,
-    )[1]
-    assert input_types == {"a": int, "b": float}
+    )
+    assert concatenated_func({"a": 1}) == 2

--- a/tests/test_dag_tree/test_dag_tree.py
+++ b/tests/test_dag_tree/test_dag_tree.py
@@ -180,4 +180,4 @@ def test_partialled_function_argument() -> None:
         inputs=input_structure,
         enforce_signature=True,
     )
-    assert concatenated_func({"a": 1}) == 2
+    assert concatenated_func({"a": 1}) == {"f": 2}

--- a/tests/test_decorators_are_compatible.py
+++ b/tests/test_decorators_are_compatible.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 from collections.abc import Callable
 from functools import partial

--- a/tests/test_decorators_are_compatible.py
+++ b/tests/test_decorators_are_compatible.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
 from functools import partial
+from typing import TYPE_CHECKING
 
 import pytest
 
 from dags.output import aggregated_output, dict_output, list_output, single_output
 from dags.signature import with_signature
-from dags.typing import GenericCallable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from dags.typing import GenericCallable
 
 decorators = [
     single_output,

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import inspect
 
 from dags.output import (
+    _create_dict_return_annotation,
+    _create_list_return_annotation,
     aggregated_output,
     dict_output,
     list_output,
@@ -110,3 +112,16 @@ def test_aggregated_output_direct_call() -> None:
 
     g = aggregated_output(f, aggregator=lambda x, y: x + y)
     assert g() == 3
+
+
+def test_create_dict_return_annotation() -> None:
+    keys = ["a", "b"]
+    tuple_of_types = ("int", float)
+    assert (
+        _create_dict_return_annotation(keys, tuple_of_types) == "{'a': int, 'b': float}"
+    )
+
+
+def test_create_list_return_annotation() -> None:
+    tuple_of_types = ("int", float)
+    assert _create_list_return_annotation(tuple_of_types) == "list[int | float]"

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-from typing import TypedDict, get_type_hints
 
 from dags.output import (
     aggregated_output,
@@ -11,59 +10,63 @@ from dags.output import (
 )
 
 
-def test_single_output_decorator() -> None:
+def test_single_output() -> None:
     @single_output
     def f() -> tuple[int, ...]:
         return (1,)
 
     assert f() == 1
 
-    def expected() -> int:
-        return 1
 
-    assert inspect.signature(f) == inspect.signature(expected)
+def test_single_output_annotations() -> None:
+    def _f(foo: bool) -> tuple[int, ...]:
+        return (int(foo),)
+
+    f = single_output(_f, set_annotations=True)
+
+    assert inspect.get_annotations(f, eval_str=True) == {
+        "foo": bool,
+        "return": int,
+    }
 
 
-def test_dict_output_decorator() -> None:
+def test_dict_output() -> None:
     @dict_output(keys=["a", "b"])
     def f() -> tuple[int, float]:
         return (1, 2.0)
 
     assert f() == {"a": 1, "b": 2.0}
 
-    class FReturn(TypedDict):
-        a: int
-        b: float
 
-    def expected() -> FReturn:
-        return {"a": 1, "b": 2.0}
+def test_dict_output_annotations() -> None:
+    @dict_output(keys=["a", "b"], set_annotations=True)
+    def f(foo: bool) -> tuple[int, float]:
+        return (int(foo), 2.0)
 
-    got_signature = inspect.signature(f)
-    expected_signature = inspect.signature(expected)
-
-    assert got_signature.parameters == expected_signature.parameters
-    # In the "dict" case, the return annotation is a TypedDict. This cannot be compared
-    # using ==, so we compare the name and implied dictionary of type hints.
-    assert (
-        got_signature.return_annotation.__name__
-        == expected_signature.return_annotation.__name__
-    )
-    assert get_type_hints(got_signature.return_annotation) == get_type_hints(
-        expected_signature.return_annotation
-    )
+    assert inspect.get_annotations(f, eval_str=True) == {
+        "foo": bool,
+        "return": {"a": int, "b": float},
+    }
 
 
-def test_list_output_decorator() -> None:
+def test_list_output() -> None:
     @list_output
     def f() -> tuple[int, float]:
         return (1, 2.0)
 
     assert f() == [1, 2.0]
 
-    def expected() -> list[int | float]:
-        return [1, 2.0]
 
-    assert inspect.signature(f) == inspect.signature(expected)
+def test_list_output_annotations() -> None:
+    def _f(foo: bool) -> tuple[int, float]:
+        return (int(foo), 2.0)
+
+    f = list_output(_f, set_annotations=True)
+
+    assert inspect.get_annotations(f, eval_str=True) == {
+        "foo": bool,
+        "return": list[int | float],
+    }
 
 
 def test_aggregated_output_decorator() -> None:

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 from typing import TypedDict, get_type_hints
 

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -67,7 +67,7 @@ def test_list_output_annotations() -> None:
 
     assert inspect.get_annotations(f, eval_str=True) == {
         "foo": bool,
-        "return": list[int | float],
+        "return": [int, float],
     }
 
 
@@ -124,4 +124,4 @@ def test_create_dict_return_annotation() -> None:
 
 def test_create_list_return_annotation() -> None:
     tuple_of_types = ("int", float)
-    assert _create_list_return_annotation(tuple_of_types) == "list[float | int]"
+    assert _create_list_return_annotation(tuple_of_types) == "[int, float]"

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -1,127 +1,95 @@
 from __future__ import annotations
 
 import inspect
+from typing import TYPE_CHECKING
+
+import pytest
 
 from dags.output import (
-    _create_dict_return_annotation,
-    _create_list_return_annotation,
     aggregated_output,
     dict_output,
     list_output,
     single_output,
 )
 
+if TYPE_CHECKING:
+    from dags.typing import GenericCallable
 
-def test_single_output() -> None:
-    @single_output
-    def f() -> tuple[int, ...]:
-        return (1,)
+
+@pytest.fixture
+def f():
+    def _f(foo: bool):  # type: ignore[no-untyped-def]
+        return (int(foo), 2.0)
+
+    # We need to set the annotations via __annotations__, because if we set it directly
+    # during the function definition, the return annotation will be converted to a
+    # single string, because of the from __future__ import annotations statement.
+    _f.__annotations__ = {"foo": "bool", "return": ("int", "float")}
+    return _f
+
+
+def test_single_output(f: GenericCallable) -> None:
+    g = single_output(f)  # type: ignore[var-annotated]
+    assert g(foo=True) == 1
+
+
+def test_single_output_annotations(f: GenericCallable) -> None:
+    g = single_output(f, set_annotations=True)  # type: ignore[var-annotated]
+    assert inspect.get_annotations(g) == {"foo": "bool", "return": "int"}
+
+
+def test_dict_output(f: GenericCallable) -> None:
+    g = dict_output(f, keys=["a", "b"])
+    assert g(foo=True) == {"a": 1, "b": 2.0}
+
+
+def test_dict_output_annotations(f: GenericCallable) -> None:
+    g = dict_output(f, keys=["a", "b"], set_annotations=True)
+    assert inspect.get_annotations(g) == {
+        "foo": "bool",
+        "return": {"a": "int", "b": "float"},
+    }
+
+
+def test_list_output(f: GenericCallable) -> None:
+    g = list_output(f)
+    assert g(foo=True) == [1, 2.0]
+
+
+def test_list_output_annotations(f: GenericCallable) -> None:
+    g = list_output(f, set_annotations=True)
+    assert inspect.get_annotations(g) == {"foo": "bool", "return": ["int", "float"]}
+
+
+def test_aggregated_output_decorator(f: GenericCallable) -> None:
+    g = aggregated_output(f, aggregator=lambda x, y: x + y)
+    assert g(foo=True) == 3
+
+
+def test_single_output_direct_call(f: GenericCallable) -> None:
+    g = single_output(f)  # type: ignore[var-annotated]
+    assert g(foo=True) == 1
+
+
+def test_single_output_decorator() -> None:
+    @single_output  # type: ignore[arg-type]
+    def f():
+        return (1, 2)
 
     assert f() == 1
 
 
-def test_single_output_annotations() -> None:
-    def _f(foo: bool) -> tuple[int, ...]:
-        return (int(foo),)
-
-    f = single_output(_f, set_annotations=True)
-
-    assert inspect.get_annotations(f, eval_str=True) == {
-        "foo": bool,
-        "return": int,
-    }
-
-
-def test_dict_output() -> None:
+def test_dict_output_decorator() -> None:
     @dict_output(keys=["a", "b"])
-    def f() -> tuple[int, float]:
-        return (1, 2.0)
+    def f():
+        return (1, 2)
 
-    assert f() == {"a": 1, "b": 2.0}
-
-
-def test_dict_output_annotations() -> None:
-    @dict_output(keys=["a", "b"], set_annotations=True)
-    def f(foo: bool) -> tuple[int, float]:
-        return (int(foo), 2.0)
-
-    assert inspect.get_annotations(f, eval_str=True) == {
-        "foo": bool,
-        "return": {"a": int, "b": float},
-    }
+    assert f() == {"a": 1, "b": 2}
 
 
-def test_list_output() -> None:
+def test_list_output_decorator() -> None:
     @list_output
-    def f() -> tuple[int, float]:
-        return (1, 2.0)
-
-    assert f() == [1, 2.0]
-
-
-def test_list_output_annotations() -> None:
-    def _f(foo: bool) -> tuple[int, float]:
-        return (int(foo), 2.0)
-
-    f = list_output(_f, set_annotations=True)
-
-    assert inspect.get_annotations(f, eval_str=True) == {
-        "foo": bool,
-        "return": [int, float],
-    }
-
-
-def test_aggregated_output_decorator() -> None:
-    @aggregated_output(aggregator=lambda x, y: x + y)
     def f():
         return (1, 2)
 
-    assert f() == 3
-
-
-def test_single_output_direct_call() -> None:
-    def f() -> tuple[int, ...]:
-        return (1,)
-
-    g = single_output(f)
-
-    assert g() == 1
-
-
-def test_dict_output_direct_call() -> None:
-    def f():
-        return (1, 2)
-
-    g = dict_output(f, keys=["a", "b"])
-
-    assert g() == {"a": 1, "b": 2}
-
-
-def test_list_output_direct_call() -> None:
-    def f():
-        return (1, 2)
-
-    g = list_output(f)
-
-    assert g() == [1, 2]
-
-
-def test_aggregated_output_direct_call() -> None:
-    def f():
-        return (1, 2)
-
-    g = aggregated_output(f, aggregator=lambda x, y: x + y)
-    assert g() == 3
-
-
-def test_create_dict_return_annotation() -> None:
-    keys = ["a", "b"]
-    tuple_of_types = ("int", float)
-    assert (
-        _create_dict_return_annotation(keys, tuple_of_types) == "{'a': int, 'b': float}"
-    )
-
-
-def test_create_list_return_annotation() -> None:
-    tuple_of_types = ("int", float)
-    assert _create_list_return_annotation(tuple_of_types) == "[int, float]"
+    assert f() == [1, 2]

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -4,7 +4,6 @@ import inspect
 from typing import TypedDict, get_type_hints
 
 from dags.output import (
-    _union_from_types_tuple,
     aggregated_output,
     dict_output,
     list_output,
@@ -108,7 +107,3 @@ def test_aggregated_output_direct_call() -> None:
 
     g = aggregated_output(f, aggregator=lambda x, y: x + y)
     assert g() == 3
-
-
-def test_union_from_types_tuple() -> None:
-    assert _union_from_types_tuple((int, float)) == int | float

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -124,4 +124,4 @@ def test_create_dict_return_annotation() -> None:
 
 def test_create_list_return_annotation() -> None:
     tuple_of_types = ("int", float)
-    assert _create_list_return_annotation(tuple_of_types) == "list[int | float]"
+    assert _create_list_return_annotation(tuple_of_types) == "list[float | int]"

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 
 import pytest

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -22,16 +22,16 @@ def example_signature() -> inspect.Signature:
 def example_signature_annotated() -> inspect.Signature:
     parameters = [
         inspect.Parameter(
-            name="a", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=int
+            name="a", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation="int"
         ),
         inspect.Parameter(
-            name="b", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=float
+            name="b", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation="float"
         ),
         inspect.Parameter(
-            name="c", kind=inspect.Parameter.KEYWORD_ONLY, annotation=bool
+            name="c", kind=inspect.Parameter.KEYWORD_ONLY, annotation="bool"
         ),
     ]
-    return inspect.Signature(parameters=parameters, return_annotation=float)
+    return inspect.Signature(parameters=parameters, return_annotation="float")
 
 
 def test_create_signature(example_signature: inspect.Signature) -> None:

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -46,9 +46,9 @@ def test_create_signature_annotated(
     example_signature_annotated: inspect.Signature,
 ) -> None:
     created = _create_signature(
-        args_types={"a": int, "b": float},
-        kwargs_types={"c": bool},
-        return_annotation=float,
+        args_types={"a": "int", "b": "float"},
+        kwargs_types={"c": "bool"},
+        return_annotation="float",
     )
     assert created == example_signature_annotated
 
@@ -67,7 +67,7 @@ def test_with_signature_decorator_valid_annotated(
     example_signature_annotated: inspect.Signature,
 ) -> None:
     @with_signature(
-        args={"a": int, "b": float}, kwargs={"c": bool}, return_annotation=float
+        args={"a": "int", "b": "float"}, kwargs={"c": "bool"}, return_annotation="float"
     )
     def f(*args, **kwargs):
         return sum(args) + sum(kwargs.values())
@@ -93,7 +93,10 @@ def test_with_signature_direct_call_valid_annotated(
         return sum(args) + sum(kwargs.values())
 
     g = with_signature(
-        f, args={"a": int, "b": float}, kwargs={"c": bool}, return_annotation=float
+        f,
+        args={"a": "int", "b": "float"},
+        kwargs={"c": "bool"},
+        return_annotation="float",
     )
 
     assert inspect.signature(g) == example_signature_annotated

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -174,11 +174,11 @@ def test_rename_arguments_decorator_annotated() -> None:
     def f(d: int, e: float, *, f: bool) -> float:
         return d + e + f
 
-    assert inspect.get_annotations(f, eval_str=True) == {
-        "a": int,
-        "b": float,
-        "c": bool,
-        "return": float,
+    assert inspect.get_annotations(f) == {
+        "a": "int",
+        "b": "float",
+        "c": "bool",
+        "return": "float",
     }
 
 
@@ -200,9 +200,9 @@ def test_rename_arguments_direct_call_annotated() -> None:
 
     g = rename_arguments(f, mapper={"e": "b", "d": "a", "f": "c"})
 
-    assert inspect.get_annotations(g, eval_str=True) == {
-        "a": int,
-        "b": float,
-        "c": bool,
-        "return": float,
+    assert inspect.get_annotations(g) == {
+        "a": "int",
+        "b": "float",
+        "c": "bool",
+        "return": "float",
     }

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -35,7 +35,10 @@ def example_signature_annotated() -> inspect.Signature:
 
 
 def test_create_signature(example_signature: inspect.Signature) -> None:
-    created = _create_signature(args_types=["a", "b"], kwargs_types=["c"])
+    created = _create_signature(
+        args_types={"a": inspect.Parameter.empty, "b": inspect.Parameter.empty},
+        kwargs_types={"c": inspect.Parameter.empty},
+    )
     assert created == example_signature
 
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -35,7 +35,7 @@ def example_signature_annotated() -> inspect.Signature:
 
 
 def test_create_signature(example_signature: inspect.Signature) -> None:
-    created = _create_signature(args=["a", "b"], kwargs=["c"])
+    created = _create_signature(args_types=["a", "b"], kwargs_types=["c"])
     assert created == example_signature
 
 
@@ -43,7 +43,9 @@ def test_create_signature_annotated(
     example_signature_annotated: inspect.Signature,
 ) -> None:
     created = _create_signature(
-        args={"a": int, "b": float}, kwargs={"c": bool}, return_annotation=float
+        args_types={"a": int, "b": float},
+        kwargs_types={"c": bool},
+        return_annotation=float,
     )
     assert created == example_signature_annotated
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -5,7 +5,7 @@ import inspect
 import pytest
 
 from dags.exceptions import InvalidFunctionArgumentsError
-from dags.signature import create_signature, rename_arguments, with_signature
+from dags.signature import _create_signature, rename_arguments, with_signature
 
 
 @pytest.fixture
@@ -35,14 +35,14 @@ def example_signature_annotated() -> inspect.Signature:
 
 
 def test_create_signature(example_signature: inspect.Signature) -> None:
-    created = create_signature(args=["a", "b"], kwargs=["c"])
+    created = _create_signature(args=["a", "b"], kwargs=["c"])
     assert created == example_signature
 
 
 def test_create_signature_annotated(
     example_signature_annotated: inspect.Signature,
 ) -> None:
-    created = create_signature(
+    created = _create_signature(
         args={"a": int, "b": float}, kwargs={"c": bool}, return_annotation=float
     )
     assert created == example_signature_annotated

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -166,10 +166,12 @@ def test_rename_arguments_decorator_annotated() -> None:
     def f(d: int, e: float, *, f: bool) -> float:
         return d + e + f
 
-    def expected(a: int, b: float, *, c: bool) -> float:
-        return a + b + c
-
-    assert inspect.signature(f) == inspect.signature(expected)
+    assert inspect.get_annotations(f, eval_str=True) == {
+        "a": int,
+        "b": float,
+        "c": bool,
+        "return": float,
+    }
 
 
 def test_rename_arguments_direct_call(example_signature: inspect.Signature) -> None:
@@ -190,7 +192,9 @@ def test_rename_arguments_direct_call_annotated() -> None:
 
     g = rename_arguments(f, mapper={"e": "b", "d": "a", "f": "c"})
 
-    def expected(a: int, b: float, *, c: bool) -> float:
-        return a + b + c
-
-    assert inspect.signature(g) == inspect.signature(expected)
+    assert inspect.get_annotations(g, eval_str=True) == {
+        "a": int,
+        "b": float,
+        "c": bool,
+        "return": float,
+    }

--- a/tests/test_without_string_annotations.py
+++ b/tests/test_without_string_annotations.py
@@ -1,3 +1,10 @@
+"""Check behavior of annotations functions when annotations are not strings.
+
+Do not add "from __future__ import annotations" to this file, otherwise we cannot
+check what happens when annotations are not strings.
+
+"""
+
 import pytest
 
 from dags.dag import FunctionExecutionInfo

--- a/tests/test_without_string_annotations.py
+++ b/tests/test_without_string_annotations.py
@@ -1,0 +1,27 @@
+import pytest
+
+from dags.dag import FunctionExecutionInfo
+from dags.exceptions import NonStringAnnotationError
+
+
+def test_function_execution_info() -> None:
+    def f(a: int, b: float) -> float:
+        return a + b
+
+    FunctionExecutionInfo(
+        name="f",
+        func=f,
+        verify_annotations=False,
+    )
+
+
+def test_function_execution_info_verify_annotations() -> None:
+    def f(a: int, b: float) -> float:
+        return a + b
+
+    with pytest.raises(NonStringAnnotationError):
+        FunctionExecutionInfo(
+            name="f",
+            func=f,
+            verify_annotations=True,
+        )


### PR DESCRIPTION
In this PR, I refactor the dags annotation handling.

### Changes

- Only allow stringified type hints.

  - **Explanation:**
  
     Working with type hints at runtime is complicated. Without adjustments, type hints are evaluated at import time and stored as a dictionary under `__annotations__` of the respective module, class, or function. In some cases, this does not work because the type hint is defined recursively, at a later stage, or because of some other issue. In these cases, one can enclose the hint using quotation marks. Another approach is to add
     ```python
     # module.py
     from __future__ import annotations
     ```
     to the top of the module ([PEP 563](https://peps.python.org/pep-0563/)). One can recover the actual types from strings using
     ```python
     import inspect
     inspect.get_annotations(func, eval_str=True)
     ```
     with Python 3.10+. In Python 3.14 we will see yet another approach, using deferred evaluation of types ([PEP 649](https://peps.python.org/pep-0649/), Larry Hastings) --potentially we will have to update dags behavior in this case.
  
  - If the user does not provide string annotations, an extensive error message is raised
  
- Add available type annotations to `dags.tree.create_input_types_tree`

- Add `dags.get_free_arguments` and `dags.get_annotations` to the top-level namespace

- Adjust the `FunctionExecutionInfo` class and handling thereof to decrease the risk of ending up in an invalid state

> [!NOTE]
> A must read when working with annotations (at runtime) is the [Annotations Best Practices](https://docs.python.org/3/howto/annotations.html) post by Larry Hastings; and potentially Subchapter "Reading Type Hints at Runtime" in Chapter 15 of Fluent Python (Luciano Ramalho).


### Example

```python
from dags import concatenate_functions

def f(g: "float") -> "float":
    return g

def g(a: "int") -> "float":
    return 1.5 * a

concatenated = concatenate_functions(
    functions=[f, g],
    return_type="dict",
    set_annotations=True,
)

import inspect
inspect.get_annotations(concatenated)

>>> {'a': 'int', 'return': {'f': 'float', 'g': 'float'}}
```


---

Closes #21 