### PR TITLE
Make type hints more expressive

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/pixi.lock
+++ b/pixi.lock
@@ -174,7 +174,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -337,7 +337,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -500,7 +500,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -664,7 +664,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   py310:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -839,7 +839,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1000,7 +1000,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1161,7 +1161,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -1323,7 +1323,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1499,7 +1499,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1661,7 +1661,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1823,7 +1823,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -1986,7 +1986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   py312:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2162,7 +2162,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -2324,7 +2324,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -2486,7 +2486,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -2649,7 +2649,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   py313:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2824,7 +2824,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -2987,7 +2987,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -3150,7 +3150,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -3314,7 +3314,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -4655,10 +4655,10 @@ packages:
   purls: []
   size: 47287
   timestamp: 1736761414276
-- pypi: .
+- pypi: ./
   name: dags
-  version: 0.3.1.dev9+g40a5ef8.d20250616
-  sha256: bd27843303ed3aa3d858d47c018520b9a9521dc35aa549ba2c57a19e3196b6b0
+  version: 0.3.1.dev12+gac6d3c8
+  sha256: 378f244e4afe106c2f08b9dcdd90ef6113323549859221ac35611bc15c3c25ac
   requires_dist:
   - flatten-dict
   - networkx

--- a/pixi.lock
+++ b/pixi.lock
@@ -174,7 +174,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -337,7 +337,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -500,7 +500,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -664,7 +664,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py310:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -839,7 +839,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1000,7 +1000,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1161,7 +1161,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -1323,7 +1323,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1499,7 +1499,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1661,7 +1661,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -1823,7 +1823,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -1986,7 +1986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py312:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2162,7 +2162,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -2324,7 +2324,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -2486,7 +2486,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -2649,7 +2649,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   py313:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2824,7 +2824,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -2987,7 +2987,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_1.conda
@@ -3150,7 +3150,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/29/93/d56fb9ba5569dc29d8263c72e46d21a2fd38741339ebf03f54cf7561828c/pdbp-1.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_1.conda
@@ -3314,7 +3314,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/23/13414ead12ee55491c25e75029b5bfce41990bc01071a1e2e07f1c642178/types_networkx-3.4.2.20250319-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -4655,10 +4655,10 @@ packages:
   purls: []
   size: 47287
   timestamp: 1736761414276
-- pypi: ./
+- pypi: .
   name: dags
-  version: 0.3.1.dev11+ga9f24fa.d20250616
-  sha256: 378f244e4afe106c2f08b9dcdd90ef6113323549859221ac35611bc15c3c25ac
+  version: 0.3.1.dev9+g40a5ef8.d20250616
+  sha256: bd27843303ed3aa3d858d47c018520b9a9521dc35aa549ba2c57a19e3196b6b0
   requires_dist:
   - flatten-dict
   - networkx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ disallow_incomplete_defs = true
 no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+disable_error_code = ["type-arg"]
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,6 @@ disallow_incomplete_defs = true
 no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-disable_error_code = ["type-arg"]
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from dags.exceptions import NonStringAnnotationError
 
@@ -12,7 +12,7 @@ import inspect
 
 
 def get_free_arguments(
-    func: Callable,
+    func: Callable[..., Any],
 ) -> list[str]:
     arguments = list(inspect.signature(func).parameters)
     if isinstance(func, functools.partial):
@@ -26,7 +26,7 @@ def get_free_arguments(
 
 @overload
 def get_annotations(
-    func: Callable,
+    func: Callable[..., Any],
     eval_str: Literal[False] = False,
     default: str | None = None,
 ) -> dict[str, str]: ...
@@ -34,14 +34,14 @@ def get_annotations(
 
 @overload
 def get_annotations(
-    func: Callable,
+    func: Callable[..., Any],
     eval_str: Literal[True] = True,
     default: type | None = None,
 ) -> dict[str, type]: ...
 
 
 def get_annotations(
-    func: Callable,
+    func: Callable[..., Any],
     eval_str: bool = False,
     default: str | type | None = None,
 ) -> dict[str, str] | dict[str, type]:

--- a/src/dags/annotations.py
+++ b/src/dags/annotations.py
@@ -5,14 +5,14 @@ from typing import TYPE_CHECKING, Literal, overload
 from dags.exceptions import NonStringAnnotationError
 
 if TYPE_CHECKING:
-    from dags.typing import GenericCallable
+    from collections.abc import Callable
 
 import functools
 import inspect
 
 
 def get_free_arguments(
-    func: GenericCallable,
+    func: Callable,
 ) -> list[str]:
     arguments = list(inspect.signature(func).parameters)
     if isinstance(func, functools.partial):
@@ -26,7 +26,7 @@ def get_free_arguments(
 
 @overload
 def get_annotations(
-    func: GenericCallable,
+    func: Callable,
     eval_str: Literal[False] = False,
     default: str | None = None,
 ) -> dict[str, str]: ...
@@ -34,14 +34,14 @@ def get_annotations(
 
 @overload
 def get_annotations(
-    func: GenericCallable,
+    func: Callable,
     eval_str: Literal[True] = True,
     default: type | None = None,
 ) -> dict[str, type]: ...
 
 
 def get_annotations(
-    func: GenericCallable,
+    func: Callable,
     eval_str: bool = False,
     default: str | type | None = None,
 ) -> dict[str, str] | dict[str, type]:

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -58,7 +58,7 @@ class FunctionExecutionInfo:
     """
 
     name: str
-    func: Callable
+    func: Callable[..., Any]
     verify_annotations: bool = False
 
     def __post_init__(self) -> None:
@@ -88,7 +88,7 @@ class FunctionExecutionInfo:
 
 
 def concatenate_functions(
-    functions: dict[str, Callable] | list[Callable],
+    functions: dict[str, Callable[..., Any]] | list[Callable[..., Any]],
     targets: str | list[str] | None = None,
     *,
     dag: nx.DiGraph[str] | None = None,
@@ -96,7 +96,7 @@ def concatenate_functions(
     aggregator: Callable[[T, T], T] | None = None,
     enforce_signature: bool = True,
     set_annotations: bool = False,
-) -> Callable:
+) -> Callable[..., Any]:
     """Combine functions to one function that generates targets.
 
     Functions can depend on the output of other functions as inputs, as long as the
@@ -171,7 +171,7 @@ def concatenate_functions(
 
 
 def create_dag(
-    functions: dict[str, Callable] | list[Callable],
+    functions: dict[str, Callable[..., Any]] | list[Callable[..., Any]],
     targets: str | list[str] | None,
 ) -> nx.DiGraph[str]:
     """Build a directed acyclic graph (DAG) from functions.
@@ -212,13 +212,13 @@ def create_dag(
 
 def _create_combined_function_from_dag(
     dag: nx.DiGraph[str],
-    functions: dict[str, Callable] | list[Callable],
+    functions: dict[str, Callable[..., Any]] | list[Callable[..., Any]],
     targets: str | list[str] | None,
     return_type: Literal["tuple", "list", "dict"] = "tuple",
     aggregator: Callable[[T, T], T] | None = None,
     enforce_signature: bool = True,
     set_annotations: bool = False,
-) -> Callable:
+) -> Callable[..., Any]:
     """Create combined function which allows executing a DAG in one function call.
 
     The arguments of the combined function are all arguments of relevant functions that
@@ -287,21 +287,21 @@ def _create_combined_function_from_dag(
 
     # Update the actual return type, as well as the return annotation of the
     # concatenated function.
-    out: Callable
+    out: Callable[..., Any]
     if isinstance(targets, str) or (aggregator is not None and len(_targets) == 1):
         out = single_output(_concatenated, set_annotations=set_annotations)
     elif aggregator is not None:
         out = aggregated_output(_concatenated, aggregator=aggregator)
     elif return_type == "list":
         out = cast(
-            "Callable",
+            "Callable[..., Any]",
             list_output(_concatenated, set_annotations=set_annotations),
         )
     elif return_type == "tuple":
         out = _concatenated
     elif return_type == "dict":
         out = cast(
-            "Callable",
+            "Callable[..., Any]",
             dict_output(_concatenated, keys=_targets, set_annotations=set_annotations),
         )
     else:
@@ -315,7 +315,7 @@ def _create_combined_function_from_dag(
 
 
 def get_ancestors(
-    functions: dict[str, Callable] | list[Callable],
+    functions: dict[str, Callable[..., Any]] | list[Callable[..., Any]],
     targets: str | list[str] | None,
     include_targets: bool = False,
 ) -> set[str]:
@@ -351,9 +351,9 @@ def get_ancestors(
 
 
 def harmonize_and_check_functions_and_targets(
-    functions: dict[str, Callable] | list[Callable],
+    functions: dict[str, Callable[..., Any]] | list[Callable[..., Any]],
     targets: str | list[str] | None,
-) -> tuple[dict[str, Callable], list[str]]:
+) -> tuple[dict[str, Callable[..., Any]], list[str]]:
     """Harmonize the type of specified functions and targets and do some checks.
 
     Args:
@@ -378,8 +378,8 @@ def harmonize_and_check_functions_and_targets(
 
 
 def _harmonize_functions(
-    functions: dict[str, Callable] | list[Callable],
-) -> dict[str, Callable]:
+    functions: dict[str, Callable[..., Any]] | list[Callable[..., Any]],
+) -> dict[str, Callable[..., Any]]:
     if not isinstance(functions, dict):
         functions_dict = {func.__name__: func for func in functions}
     else:
@@ -409,7 +409,7 @@ def _fail_if_targets_have_wrong_types(
 
 
 def _fail_if_functions_are_missing(
-    functions: dict[str, Callable],
+    functions: dict[str, Callable[..., Any]],
     targets: list[str],
 ) -> None:
     targets_not_in_functions = set(targets) - set(functions)
@@ -430,7 +430,7 @@ def _fail_if_dag_contains_cycle(dag: nx.DiGraph[str]) -> None:
 
 
 def _create_complete_dag(
-    functions: dict[str, Callable],
+    functions: dict[str, Callable[..., Any]],
 ) -> nx.DiGraph[str]:
     """Create the complete DAG.
 
@@ -480,7 +480,7 @@ def _limit_dag_to_targets_and_their_ancestors(
 
 
 def create_arguments_of_concatenated_function(
-    functions: dict[str, Callable],
+    functions: dict[str, Callable[..., Any]],
     dag: nx.DiGraph[str],
 ) -> list[str]:
     """Create the signature of the concatenated function.
@@ -500,7 +500,7 @@ def create_arguments_of_concatenated_function(
 
 
 def create_execution_info(
-    functions: dict[str, Callable],
+    functions: dict[str, Callable[..., Any]],
     dag: nx.DiGraph[str],
     verify_annotations: bool = False,
 ) -> dict[str, FunctionExecutionInfo]:

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -638,6 +638,14 @@ def get_annotations_from_execution_info(
             earlier_type = types[arg]
             current_type = info.argument_annotations[arg]
 
+            # The following condition is a hack to deal with overloaded type
+            # annotations. E.g., we may have a function that an int and returns an int,
+            # or it takes a float and returns a float. We can achieve that with
+            # @overload, but the type hints will be "int | float". If we just checked]
+            # for equality, we would get an error if a downstream or upstream function
+            # required an int or a float. We will not be able to do much better unless
+            # we switch away from string-type annotations or replicate the entire logic
+            # of a static type checker, both of which are infeasible at the moment.
             if earlier_type not in current_type and current_type not in earlier_type:
                 arg_is_function = arg in execution_info
                 if arg_is_function:

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from dags.dag import (
     concatenate_functions,
@@ -207,10 +207,10 @@ def functions_without_tree_logic(
 
 
 def one_function_without_tree_logic(
-    function: Callable,
+    function: Callable[..., Any],
     tree_path: tuple[str, ...],
     top_level_namespace: set[str],
-) -> Callable:
+) -> Callable[..., Any]:
     """Convert a single function to work without tree logic.
 
     Args:
@@ -259,7 +259,7 @@ def _get_top_level_namespace_final(
 
 
 def _map_parameters_rel_to_abs(
-    func: Callable,
+    func: Callable[..., Any],
     current_namespace: tuple[str, ...],
     top_level_namespace: set[str],
 ) -> dict[str, str]:

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     import networkx as nx
 
     from dags.tree.typing import (
-        GenericCallable,
         NestedFunctionDict,
         NestedInputDict,
         NestedInputStructureDict,
@@ -208,10 +207,10 @@ def functions_without_tree_logic(
 
 
 def one_function_without_tree_logic(
-    function: GenericCallable,
+    function: Callable,
     tree_path: tuple[str, ...],
     top_level_namespace: set[str],
-) -> GenericCallable:
+) -> Callable:
     """Convert a single function to work without tree logic.
 
     Args:
@@ -260,7 +259,7 @@ def _get_top_level_namespace_final(
 
 
 def _map_parameters_rel_to_abs(
-    func: GenericCallable,
+    func: Callable,
     current_namespace: tuple[str, ...],
     top_level_namespace: set[str],
 ) -> dict[str, str]:

--- a/src/dags/tree/typing.py
+++ b/src/dags/tree/typing.py
@@ -20,9 +20,9 @@ FlatQNameDict = dict[str, Any]
 FlatTreePathDict = dict[tuple[str, ...], Any]
 
 # Function-related types
-NestedFunctionDict = Mapping[str, "Callable | NestedFunctionDict"]
-QNameFunctionDict = dict[str, Callable]
-TreePathFunctionDict = dict[tuple[str, ...], Callable]
+NestedFunctionDict = Mapping[str, "Callable[..., Any] | NestedFunctionDict"]
+QNameFunctionDict = dict[str, Callable[..., Any]]
+TreePathFunctionDict = dict[tuple[str, ...], Callable[..., Any]]
 
 # Input structure types
 NestedInputStructureDict = Mapping[str, "str | None | NestedInputStructureDict"]

--- a/src/dags/tree/typing.py
+++ b/src/dags/tree/typing.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any, TypeVar
-
-from dags.typing import GenericCallable
 
 # Type variables
 T = TypeVar("T")
@@ -22,9 +20,9 @@ FlatQNameDict = dict[str, Any]
 FlatTreePathDict = dict[tuple[str, ...], Any]
 
 # Function-related types
-NestedFunctionDict = Mapping[str, "GenericCallable | NestedFunctionDict"]
-QNameFunctionDict = dict[str, GenericCallable]
-TreePathFunctionDict = dict[tuple[str, ...], GenericCallable]
+NestedFunctionDict = Mapping[str, "Callable | NestedFunctionDict"]
+QNameFunctionDict = dict[str, Callable]
+TreePathFunctionDict = dict[tuple[str, ...], Callable]
 
 # Input structure types
 NestedInputStructureDict = Mapping[str, "str | None | NestedInputStructureDict"]

--- a/src/dags/typing.py
+++ b/src/dags/typing.py
@@ -1,15 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, Literal, ParamSpec, TypeVar
+from typing import ParamSpec, TypeVar
 
 from typing_extensions import TypeVarTuple
-
-GenericCallable = Callable[..., Any]
-FunctionCollection = dict[str, GenericCallable] | list[GenericCallable]
-TargetType = str | list[str] | None
-CombinedFunctionReturnType = Literal["tuple", "list", "dict"]
-
 
 # ParamSpec representing the full signature (positional and keyword parameters) of a
 # callable

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import TYPE_CHECKING
+from typing import Literal
 
 import numpy as np
 import pytest
@@ -11,9 +11,6 @@ from numpy.typing import NDArray
 from dags.annotations import get_annotations, verify_annotations_are_strings
 from dags.dag import concatenate_functions
 from dags.exceptions import AnnotationMismatchError, NonStringAnnotationError
-
-if TYPE_CHECKING:
-    from dags.typing import CombinedFunctionReturnType
 
 
 def test_argument_annotations_mismatch() -> None:
@@ -56,7 +53,7 @@ def test_argument_annoations_mismatch_with_return_annotation() -> None:
 
 @pytest.mark.parametrize("return_type", ["tuple", "list", "dict"])
 def test_concatenate_functions_without_input(
-    return_type: CombinedFunctionReturnType,
+    return_type: Literal["tuple", "list", "dict"],
 ) -> None:
     concatenated = concatenate_functions(
         functions={},

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from functools import partial
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 
@@ -53,14 +53,14 @@ def _complete_utility(wage: float, working_hours: int, leisure_weight: float) ->
 
 
 @pytest.fixture
-def concatenated_no_target() -> Callable:
+def concatenated_no_target() -> Callable[..., Any]:
     return concatenate_functions(
         functions=[_utility, _leisure, _consumption], set_annotations=True
     )
 
 
 @pytest.fixture
-def concatenated_utility_target() -> Callable:
+def concatenated_utility_target() -> Callable[..., Any]:
     return concatenate_functions(
         functions=[_utility, _unrelated, _leisure, _consumption],
         targets="_utility",
@@ -69,7 +69,7 @@ def concatenated_utility_target() -> Callable:
 
 
 def test_concatenate_functions_with_dag(
-    concatenated_no_target: Callable,
+    concatenated_no_target: Callable[..., Any],
 ) -> None:
     dag = create_dag(
         functions=[_utility, _unrelated, _leisure, _consumption], targets="_utility"
@@ -83,7 +83,7 @@ def test_concatenate_functions_with_dag(
 
 
 def test_concatenate_functions_no_target_results(
-    concatenated_no_target: Callable,
+    concatenated_no_target: Callable[..., Any],
 ) -> None:
     calculated_result = concatenated_no_target(
         wage=5, working_hours=8, leisure_weight=2
@@ -101,7 +101,7 @@ def test_concatenate_functions_no_target_results(
 
 
 def test_concatenate_functions_no_target_annotations(
-    concatenated_no_target: Callable,
+    concatenated_no_target: Callable[..., Any],
 ) -> None:
     expected_annotations = {
         "working_hours": "int",
@@ -113,7 +113,7 @@ def test_concatenate_functions_no_target_annotations(
 
 
 def test_concatenate_functions_single_target_results(
-    concatenated_utility_target: Callable,
+    concatenated_utility_target: Callable[..., Any],
 ) -> None:
     calculated_result = concatenated_utility_target(
         wage=5, working_hours=8, leisure_weight=2
@@ -124,7 +124,7 @@ def test_concatenate_functions_single_target_results(
 
 
 def test_concatenate_functions_single_target_annotations(
-    concatenated_utility_target: Callable,
+    concatenated_utility_target: Callable[..., Any],
 ) -> None:
     expected_annotations = {
         "working_hours": "int",
@@ -273,7 +273,9 @@ def test_partialled_argument_is_ignored() -> None:
         },
     ],
 )
-def test_fail_if_cycle_in_dag(funcs: dict[str, Callable] | list[Callable]) -> None:
+def test_fail_if_cycle_in_dag(
+    funcs: dict[str, Callable[..., Any]] | list[Callable[..., Any]],
+) -> None:
     with pytest.raises(CyclicDependencyError):
         create_dag(functions=funcs, targets=["_utility"])
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pytest
 
@@ -17,11 +17,7 @@ from dags.dag import (
 from dags.exceptions import CyclicDependencyError, DagsError
 
 if TYPE_CHECKING:
-    from dags.typing import (
-        CombinedFunctionReturnType,
-        FunctionCollection,
-        GenericCallable,
-    )
+    from collections.abc import Callable
 
 
 def _utility(_consumption: float, _leisure: int, leisure_weight: float) -> float:
@@ -57,14 +53,14 @@ def _complete_utility(wage: float, working_hours: int, leisure_weight: float) ->
 
 
 @pytest.fixture
-def concatenated_no_target() -> GenericCallable:
+def concatenated_no_target() -> Callable:
     return concatenate_functions(
         functions=[_utility, _leisure, _consumption], set_annotations=True
     )
 
 
 @pytest.fixture
-def concatenated_utility_target() -> GenericCallable:
+def concatenated_utility_target() -> Callable:
     return concatenate_functions(
         functions=[_utility, _unrelated, _leisure, _consumption],
         targets="_utility",
@@ -73,7 +69,7 @@ def concatenated_utility_target() -> GenericCallable:
 
 
 def test_concatenate_functions_with_dag(
-    concatenated_no_target: GenericCallable,
+    concatenated_no_target: Callable,
 ) -> None:
     dag = create_dag(
         functions=[_utility, _unrelated, _leisure, _consumption], targets="_utility"
@@ -87,7 +83,7 @@ def test_concatenate_functions_with_dag(
 
 
 def test_concatenate_functions_no_target_results(
-    concatenated_no_target: GenericCallable,
+    concatenated_no_target: Callable,
 ) -> None:
     calculated_result = concatenated_no_target(
         wage=5, working_hours=8, leisure_weight=2
@@ -105,7 +101,7 @@ def test_concatenate_functions_no_target_results(
 
 
 def test_concatenate_functions_no_target_annotations(
-    concatenated_no_target: GenericCallable,
+    concatenated_no_target: Callable,
 ) -> None:
     expected_annotations = {
         "working_hours": "int",
@@ -117,7 +113,7 @@ def test_concatenate_functions_no_target_annotations(
 
 
 def test_concatenate_functions_single_target_results(
-    concatenated_utility_target: GenericCallable,
+    concatenated_utility_target: Callable,
 ) -> None:
     calculated_result = concatenated_utility_target(
         wage=5, working_hours=8, leisure_weight=2
@@ -128,7 +124,7 @@ def test_concatenate_functions_single_target_results(
 
 
 def test_concatenate_functions_single_target_annotations(
-    concatenated_utility_target: GenericCallable,
+    concatenated_utility_target: Callable,
 ) -> None:
     expected_annotations = {
         "working_hours": "int",
@@ -141,7 +137,7 @@ def test_concatenate_functions_single_target_annotations(
 
 @pytest.mark.parametrize("return_type", ["tuple", "list", "dict"])
 def test_concatenate_functions_multi_target_result(
-    return_type: CombinedFunctionReturnType,
+    return_type: Literal["tuple", "list", "dict"],
 ) -> None:
     concatenated = concatenate_functions(
         functions=[_utility, _unrelated, _leisure, _consumption],
@@ -167,7 +163,7 @@ def test_concatenate_functions_multi_target_result(
 
 @pytest.mark.parametrize("return_type", ["tuple", "list", "dict"])
 def test_concatenate_functions_multi_target_annotations(
-    return_type: CombinedFunctionReturnType,
+    return_type: Literal["tuple", "list", "dict"],
 ) -> None:
     concatenated = concatenate_functions(
         functions=[_utility, _unrelated, _leisure, _consumption],
@@ -277,7 +273,7 @@ def test_partialled_argument_is_ignored() -> None:
         },
     ],
 )
-def test_fail_if_cycle_in_dag(funcs: FunctionCollection) -> None:
+def test_fail_if_cycle_in_dag(funcs: dict[str, Callable] | list[Callable]) -> None:
     with pytest.raises(CyclicDependencyError):
         create_dag(functions=funcs, targets=["_utility"])
 

--- a/tests/test_dag_tree/test_parameters.py
+++ b/tests/test_dag_tree/test_parameters.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -105,7 +105,7 @@ def test_get_top_level_namespace_initial(
     ],
 )
 def test_create_parameter_name_mapper(
-    func: Callable,
+    func: Callable[..., Any],
     current_namespace: tuple[str, ...],
     top_level_namespace: set[str],
     expected: dict[str, str],

--- a/tests/test_dag_tree/test_parameters.py
+++ b/tests/test_dag_tree/test_parameters.py
@@ -17,7 +17,7 @@ from dags.tree.dag_tree import (
 
 if TYPE_CHECKING:
     from dags.tree.typing import (
-        GenericCallable,
+        Callable,
         NestedFunctionDict,
         NestedInputStructureDict,
     )
@@ -105,7 +105,7 @@ def test_get_top_level_namespace_initial(
     ],
 )
 def test_create_parameter_name_mapper(
-    func: GenericCallable,
+    func: Callable,
     current_namespace: tuple[str, ...],
     top_level_namespace: set[str],
     expected: dict[str, str],

--- a/tests/test_decorators_are_compatible.py
+++ b/tests/test_decorators_are_compatible.py
@@ -12,8 +12,6 @@ from dags.signature import with_signature
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from dags.typing import GenericCallable
-
 decorators = [
     single_output,
     list_output,
@@ -24,7 +22,7 @@ decorators = [
 
 @pytest.mark.parametrize("decorator", decorators)
 def test_output_decorators_preserve_signature_created_by_with_signature(
-    decorator: Callable[[GenericCallable], GenericCallable],
+    decorator: Callable[[Callable], Callable],
 ) -> None:
     @with_signature(args=["a"], kwargs=["b"])
     def f(*args, **kwargs):

--- a/tests/test_decorators_are_compatible.py
+++ b/tests/test_decorators_are_compatible.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -22,7 +22,7 @@ decorators = [
 
 @pytest.mark.parametrize("decorator", decorators)
 def test_output_decorators_preserve_signature_created_by_with_signature(
-    decorator: Callable[[Callable], Callable],
+    decorator: Callable[[Callable[..., Any]], Callable[..., Any]],
 ) -> None:
     @with_signature(args=["a"], kwargs=["b"])
     def f(*args, **kwargs):

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -13,7 +13,7 @@ from dags.output import (
 )
 
 if TYPE_CHECKING:
-    from dags.typing import GenericCallable
+    from collections.abc import Callable
 
 
 @pytest.fixture
@@ -28,22 +28,22 @@ def f():
     return _f
 
 
-def test_single_output(f: GenericCallable) -> None:
+def test_single_output(f: Callable) -> None:
     g = single_output(f)  # type: ignore[var-annotated]
     assert g(foo=True) == 1
 
 
-def test_single_output_annotations(f: GenericCallable) -> None:
+def test_single_output_annotations(f: Callable) -> None:
     g = single_output(f, set_annotations=True)  # type: ignore[var-annotated]
     assert inspect.get_annotations(g) == {"foo": "bool", "return": "int"}
 
 
-def test_dict_output(f: GenericCallable) -> None:
+def test_dict_output(f: Callable) -> None:
     g = dict_output(f, keys=["a", "b"])
     assert g(foo=True) == {"a": 1, "b": 2.0}
 
 
-def test_dict_output_annotations(f: GenericCallable) -> None:
+def test_dict_output_annotations(f: Callable) -> None:
     g = dict_output(f, keys=["a", "b"], set_annotations=True)
     assert inspect.get_annotations(g) == {
         "foo": "bool",
@@ -51,22 +51,22 @@ def test_dict_output_annotations(f: GenericCallable) -> None:
     }
 
 
-def test_list_output(f: GenericCallable) -> None:
+def test_list_output(f: Callable) -> None:
     g = list_output(f)
     assert g(foo=True) == [1, 2.0]
 
 
-def test_list_output_annotations(f: GenericCallable) -> None:
+def test_list_output_annotations(f: Callable) -> None:
     g = list_output(f, set_annotations=True)
     assert inspect.get_annotations(g) == {"foo": "bool", "return": ["int", "float"]}
 
 
-def test_aggregated_output_decorator(f: GenericCallable) -> None:
+def test_aggregated_output_decorator(f: Callable) -> None:
     g = aggregated_output(f, aggregator=lambda x, y: x + y)
     assert g(foo=True) == 3
 
 
-def test_single_output_direct_call(f: GenericCallable) -> None:
+def test_single_output_direct_call(f: Callable) -> None:
     g = single_output(f)  # type: ignore[var-annotated]
     assert g(foo=True) == 1
 

--- a/tests/test_process_output.py
+++ b/tests/test_process_output.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -28,22 +28,22 @@ def f():
     return _f
 
 
-def test_single_output(f: Callable) -> None:
+def test_single_output(f: Callable[..., Any]) -> None:
     g = single_output(f)  # type: ignore[var-annotated]
     assert g(foo=True) == 1
 
 
-def test_single_output_annotations(f: Callable) -> None:
+def test_single_output_annotations(f: Callable[..., Any]) -> None:
     g = single_output(f, set_annotations=True)  # type: ignore[var-annotated]
     assert inspect.get_annotations(g) == {"foo": "bool", "return": "int"}
 
 
-def test_dict_output(f: Callable) -> None:
+def test_dict_output(f: Callable[..., Any]) -> None:
     g = dict_output(f, keys=["a", "b"])
     assert g(foo=True) == {"a": 1, "b": 2.0}
 
 
-def test_dict_output_annotations(f: Callable) -> None:
+def test_dict_output_annotations(f: Callable[..., Any]) -> None:
     g = dict_output(f, keys=["a", "b"], set_annotations=True)
     assert inspect.get_annotations(g) == {
         "foo": "bool",
@@ -51,22 +51,22 @@ def test_dict_output_annotations(f: Callable) -> None:
     }
 
 
-def test_list_output(f: Callable) -> None:
+def test_list_output(f: Callable[..., Any]) -> None:
     g = list_output(f)
     assert g(foo=True) == [1, 2.0]
 
 
-def test_list_output_annotations(f: Callable) -> None:
+def test_list_output_annotations(f: Callable[..., Any]) -> None:
     g = list_output(f, set_annotations=True)
     assert inspect.get_annotations(g) == {"foo": "bool", "return": ["int", "float"]}
 
 
-def test_aggregated_output_decorator(f: Callable) -> None:
+def test_aggregated_output_decorator(f: Callable[..., Any]) -> None:
     g = aggregated_output(f, aggregator=lambda x, y: x + y)
     assert g(foo=True) == 3
 
 
-def test_single_output_direct_call(f: Callable) -> None:
+def test_single_output_direct_call(f: Callable[..., Any]) -> None:
     g = single_output(f)  # type: ignore[var-annotated]
     assert g(foo=True) == 1
 


### PR DESCRIPTION
In this PR, we replace some of the type aliases with their definitions. The aim is to make the code more expressive and readable, by admitting some code duplication.

Additionally, a config file for the code coverage is added, where we specify to ignore lines in the `TYPE_CHECKING` block.