### PR TITLE
Only import from typing_extensions if TYPE_CHECKING

### DIFF
--- a/src/dags/output.py
+++ b/src/dags/output.py
@@ -4,12 +4,12 @@ import functools
 import inspect
 from typing import TYPE_CHECKING, overload
 
-from typing_extensions import Unpack
-
 from dags.exceptions import DagsError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from typing_extensions import Unpack
 
     from dags.typing import MixedTupleType, P, T
 

--- a/src/dags/typing.py
+++ b/src/dags/typing.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from typing import ParamSpec, TypeVar
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
-from typing_extensions import TypeVarTuple
+if TYPE_CHECKING:
+    from typing_extensions import TypeVarTuple
 
-# ParamSpec representing the full signature (positional and keyword parameters) of a
-# callable
-P = ParamSpec("P")
-# TypeVar representing the return type of a callable
-R = TypeVar("R")
-# Generic type variable for use in type constructors
-T = TypeVar("T")
-# Variadic TypeVar for tuples of arbitrary length with heterogeneous element types
-MixedTupleType = TypeVarTuple("MixedTupleType")
+    # ParamSpec representing the full signature (positional and keyword parameters) of a
+    # callable
+    P = ParamSpec("P")
+    # TypeVar representing the return type of a callable
+    R = TypeVar("R")
+    # Generic type variable for use in type constructors
+    T = TypeVar("T")
+    # Variadic TypeVar for tuples of arbitrary length with heterogeneous element types
+    MixedTupleType = TypeVarTuple("MixedTupleType")


### PR DESCRIPTION
In this PR, we move all `typing_extensions` imports into `TYPE_CHECKING` blocks.

### Why

- Imports from `typing_extensions` are only needed during type checking
- The library `typing_extensions` needed to be installed, but was not listed as a dependency 