### PR TITLE
Allow passing return type of aggregated outputs or try to infer it.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,11 @@ repos:
       - id: check-ast
       - id: check-docstring-first
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.11
     hooks:
       - id: ruff-check
         types_or:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ This is a record of all past dags releases and what went into them in reverse
 chronological order. We follow [semantic versioning](https://semver.org/) and all
 releases are available on [conda-forge](https://anaconda.org/conda-forge/dags).
 
+## 0.4.3
+
+- :gh:`61` Allow passing return type of aggregated outputs or try to infer it.
+  (:ghuser:`hmgaudecker`).
+
 ## 0.4.2
 
 - :gh:`59` Add support for Python 3.14, simplify (:ghuser:`hmgaudecker`).

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -650,7 +650,11 @@ def _infer_aggregator_return_type(
     Uses a three-tier approach:
     1. If explicit_type is provided, use it directly.
     2. Try to get the return annotation from the aggregator function.
-    3. If all targets have the same type, use that (aggregators preserve type).
+    3. If all targets have the same type, assume the aggregator preserves it.
+
+    Note: Tier 3 is a heuristic that works for aggregators like `logical_and` or
+    `max`, but may be wrong for type-promoting aggregators (e.g., summing bools
+    returns int, not bool). Use explicit_type or a typed aggregator in such cases.
 
     Args:
         aggregator: The binary reduction function.
@@ -675,7 +679,7 @@ def _infer_aggregator_return_type(
     except Exception:  # noqa: BLE001, S110
         pass
 
-    # 3. If all targets have the same type, use it (aggregators typically preserve type)
+    # 3. If all targets have the same type, assume the aggregator preserves it
     non_missing = [t for t in target_types if t != "no_annotation_found"]
     if non_missing and len(set(non_missing)) == 1:
         return non_missing[0]

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -99,6 +99,7 @@ def concatenate_functions(
     dag: nx.DiGraph[str] | None = None,
     return_type: Literal["tuple", "list", "dict"] = "tuple",
     aggregator: Callable[[T, T], T] | None = None,
+    aggregator_return_type: str | None = None,
     enforce_signature: bool = True,
     set_annotations: bool = False,
     lexsort_key: Callable[[str], Any] | None = None,
@@ -126,6 +127,11 @@ def concatenate_functions(
             targets are a single string or if an aggregator is provided.
         aggregator (callable or None): Binary reduction function that is used to
             aggregate the targets into a single target.
+        aggregator_return_type (str or None): Explicit return type annotation for the
+            aggregated result. If None and set_annotations is True, the return type
+            is inferred from the aggregator's annotations or from the target types
+            (if all targets have the same type). This parameter is only used when
+            an aggregator is provided.
         enforce_signature (bool): If True, the signature of the concatenated function
             is enforced. Otherwise it is only provided for introspection purposes.
             Enforcing the signature has a small runtime overhead.
@@ -167,6 +173,7 @@ def concatenate_functions(
         targets=targets,
         return_type=return_type,
         aggregator=aggregator,
+        aggregator_return_type=aggregator_return_type,
         enforce_signature=enforce_signature,
         set_annotations=set_annotations,
         lexsort_key=lexsort_key,
@@ -219,6 +226,7 @@ def _create_combined_function_from_dag(
     targets: str | list[str] | None,
     return_type: Literal["tuple", "list", "dict"] = "tuple",
     aggregator: Callable[[T, T], T] | None = None,
+    aggregator_return_type: str | None = None,
     enforce_signature: bool = True,
     set_annotations: bool = False,
     lexsort_key: Callable[[str], Any] | None = None,
@@ -298,16 +306,29 @@ def _create_combined_function_from_dag(
     if isinstance(targets, str) or (aggregator is not None and len(_targets) == 1):
         out = single_output(func=_concatenated, set_annotations=set_annotations)
     elif aggregator is not None:
-        out = aggregated_output(func=_concatenated, aggregator=aggregator)
+        inferred_return_type: str | None = None
         if set_annotations:
-            warnings.warn(
-                message=(
-                    "Cannot infer return annotation when using an aggregator on "
-                    "multiple targets."
-                ),
-                category=DagsWarning,
-                stacklevel=2,
+            target_types = tuple(_exec_info[t].return_annotation for t in _targets)
+            inferred_return_type = _infer_aggregator_return_type(
+                aggregator=aggregator,
+                explicit_type=aggregator_return_type,
+                target_types=target_types,
             )
+            if inferred_return_type is None:
+                warnings.warn(
+                    message=(
+                        "Cannot infer return annotation when using an aggregator on "
+                        "multiple targets. Consider providing aggregator_return_type."
+                    ),
+                    category=DagsWarning,
+                    stacklevel=2,
+                )
+        out = aggregated_output(
+            func=_concatenated,
+            aggregator=aggregator,
+            set_annotations=set_annotations,
+            return_annotation=inferred_return_type,
+        )
     elif return_type == "list":
         out = cast(
             "Callable[..., Any]",
@@ -617,6 +638,49 @@ def _create_concatenated_function(
         return tuple(results[target] for target in targets)
 
     return concatenated
+
+
+def _infer_aggregator_return_type(
+    aggregator: Callable[[T, T], T],
+    explicit_type: str | None,
+    target_types: tuple[str, ...],
+) -> str | None:
+    """Infer the return type annotation for an aggregated function.
+
+    Uses a three-tier approach:
+    1. If explicit_type is provided, use it directly.
+    2. Try to get the return annotation from the aggregator function.
+    3. If all targets have the same type, use that (aggregators preserve type).
+
+    Args:
+        aggregator: The binary reduction function.
+        explicit_type: Explicitly provided return type, if any.
+        target_types: The return types of the target functions.
+
+    Returns
+    -------
+        The inferred return type as a string, or None if inference failed.
+
+    """
+    # 1. Explicit type wins
+    if explicit_type is not None:
+        return explicit_type
+
+    # 2. Try aggregator's annotations
+    try:
+        agg_annot = get_annotations(aggregator)
+        ret = agg_annot.get("return", "no_annotation_found")
+        if ret != "no_annotation_found":
+            return ret
+    except Exception:  # noqa: BLE001, S110
+        pass
+
+    # 3. If all targets have the same type, use it (aggregators typically preserve type)
+    non_missing = [t for t in target_types if t != "no_annotation_found"]
+    if non_missing and len(set(non_missing)) == 1:
+        return non_missing[0]
+
+    return None
 
 
 def get_annotations_from_execution_info(


### PR DESCRIPTION
An (IMO) actually better fix to the problem in #60.

# Problem

When using concatenate_functions with an aggregator on multiple targets and set_annotations=True, dags couldn't infer the return type and always issued a warning:

```py
# Before: always warned, no return annotation set
concatenate_functions(
    functions={"f1": f1, "f2": f2},
    targets=["f1", "f2"],
    aggregator=jnp.logical_and,
    set_annotations=True,  # Warning: "Cannot infer return annotation..."
)
```

# Solution

## New parameter in concatenate_functions (dag.py:102)

```py
    aggregator_return_type: str | None = None
```

Allows explicit specification when inference isn't possible.

## New inference function (dag.py:630-669)

```py
def _infer_aggregator_return_type(aggregator, explicit_type, target_types) -> str | None:
```

Three-tier inference:
- Tier 1: Use explicit_type if provided
- Tier 2: Check aggregator's return annotation
- Tier 3: If all targets have the same type, use that (aggregators typically preserve type: T, T -> T)

## Extended aggregated_output (output.py:144-184)

```py
def aggregated_output(
    func=None,
    *,
    aggregator=None,
    set_annotations: bool = False,      # NEW
    return_annotation: str | None = None,  # NEW
)
```

Now applies return annotation to the wrapper when provided.
