### PR TITLE
Loosen type annotation of rename_arguments decorator to prevent lots of `# ty: ignore`s.

### DIFF
--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -189,18 +189,18 @@ def rename_arguments(
     func: Callable[P, R],
     *,
     mapper: dict[str, str],
-) -> Callable[P, R]: ...
+) -> Callable[..., R]: ...
 
 
 @overload
 def rename_arguments(
     *, mapper: dict[str, str]
-) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
+) -> Callable[[Callable[P, R]], Callable[..., R]]: ...
 
 
 def rename_arguments(  # noqa: C901
     func: Callable[P, R] | None = None, *, mapper: dict[str, str] | None = None
-) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+) -> Callable[..., R] | Callable[[Callable[P, R]], Callable[..., R]]:
     """Rename positional and keyword arguments of func.
 
     Args:
@@ -213,7 +213,7 @@ def rename_arguments(  # noqa: C901
         function: The function with renamed arguments.
     """
 
-    def decorator_rename_arguments(func: Callable[P, R]) -> Callable[P, R]:
+    def decorator_rename_arguments(func: Callable[P, R]) -> Callable[..., R]:
         old_signature = inspect.signature(func)
         old_parameters: dict[str, inspect.Parameter] = dict(old_signature.parameters)
         old_annotations = get_annotations(func)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -189,7 +189,7 @@ def test_rename_arguments_direct_call(example_signature: inspect.Signature) -> N
 
     assert inspect.signature(g) == example_signature
 
-    assert g(b=2, c=3, a=1) == (1, 2, 3)  # ty: ignore[missing-argument,unknown-argument]
+    assert g(b=2, c=3, a=1) == (1, 2, 3)
 
 
 def test_rename_arguments_direct_call_annotated() -> None:


### PR DESCRIPTION
Tiny follow-up to #62. Basically, ty 0.0.10 started flagging the results of `rename_arguments`; see longer explanation below. Without this PR, the same `ty: ignore` statements would become necessary in lots of typed user code.

Solution here is to change `rename_argument`'s return type from `Callable[P, R]` to `Callable[..., R]`

Why this works: The previous signature claimed the returned function preserved the input's `ParamSpec` `P`, which was incorrect - the parameter names are changed at runtime. The new signature honestly admits we can't express the new parameter signature at type-check time, while still preserving the return type `R`.

Trade-off: Callers lose parameter type checking on renamed functions, but since the original `ParamSpec` was inaccurate anyway (wrong names), this is more honest. The return type is still properly tracked.
   


---

The issue is due to upgrading from ty 0.0.9 to 0.0.11.

Root cause: The `rename_arguments` function is typed as:

```py
@overload
def rename_arguments(
    func: Callable[P, R],
    *,
    mapper: dict[str, str],
) -> Callable[P, R]: ...
```

This signature says the returned function preserves the `ParamSpec` `P` of the input. So when you do:

```py
def f(d, e, *, f): ...
g = rename_arguments(f, mapper={"e": "b", "d": "a", "f": "c"})
```

ty infers `g` has parameters `d`, `e`, `f` (from `P`). But at runtime, `g` actually has parameters `a`, `b`, `c`.

Why it broke: ty 0.0.10 included "Fix handling of ParamSpec in overloaded functions" which improved ParamSpec checking. With this fix, ty now correctly validates that `g(b=2, c=3, a=1)`:
- `missing-argument`: expects `d`, `e`, `f` but they're not provided
- `unknown-argument`: `a`, `b`, `c` aren't in the expected signature

This is a fundamental limitation - Python's type system cannot express that a decorator changes parameter names. The ignore comment is the correct workaround.

Sources:
- https://github.com/astral-sh/ty/releases/tag/0.0.10
- https://github.com/astral-sh/ty/releases/tag/0.0.11
- https://github.com/astral-sh/ty/blob/main/CHANGELOG.md
