### PR TITLE
Improve error messages from concatenated functions.

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -178,9 +178,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Calling without arguments now raises an error, because dags needs the external inputs:"
-   ]
+   "source": "Calling without arguments raises an `InvalidFunctionArgumentsError`, telling you exactly which inputs are missing:"
   },
   {
    "cell_type": "code",

--- a/src/dags/dag.py
+++ b/src/dags/dag.py
@@ -619,11 +619,6 @@ def _create_concatenated_function(
         args = arglist
         return_annotation = inspect.Parameter.empty
 
-    @with_signature(
-        args=args,
-        enforce=enforce_signature,
-        return_annotation=return_annotation,
-    )
     def concatenated(*args: Any, **kwargs: Any) -> tuple[Any, ...]:
         results = {**dict(zip(arglist, args, strict=False)), **kwargs}
         for name, info in execution_info.items():
@@ -633,7 +628,13 @@ def _create_concatenated_function(
 
         return tuple(results[target] for target in targets)
 
-    return concatenated
+    concatenated.__name__ = "The concatenated function"
+    return with_signature(
+        concatenated,
+        args=args,
+        enforce=enforce_signature,
+        return_annotation=return_annotation,
+    )
 
 
 def _infer_aggregator_return_type(

--- a/src/dags/signature.py
+++ b/src/dags/signature.py
@@ -137,6 +137,9 @@ def with_signature(
                 _fail_if_invalid_keyword_arguments(
                     present_kwargs, valid_kwargs, funcname
                 )
+                _fail_if_missing_arguments(
+                    present_args, present_kwargs, valid_kwargs, funcname
+                )
             return func(*args, **kwargs)
 
         wrapper_with_signature.__signature__ = signature  # ty: ignore[unresolved-attribute]
@@ -153,7 +156,7 @@ def _fail_if_too_many_positional_arguments(
 ) -> None:
     if len(present_args) > len(argnames):
         msg = (
-            f"{funcname}() takes {len(argnames)} positional arguments "
+            f"{funcname} takes {len(argnames)} positional arguments "
             f"but {len(present_args)} were given"
         )
         raise InvalidFunctionArgumentsError(msg)
@@ -166,7 +169,7 @@ def _fail_if_duplicated_arguments(
     if problematic:
         s = "s" if len(problematic) >= 2 else ""  # noqa: PLR2004
         problem_str = ", ".join(list(problematic))
-        msg = f"{funcname}() got multiple values for argument{s} {problem_str}"
+        msg = f"{funcname} got multiple values for argument{s} {problem_str}"
         raise InvalidFunctionArgumentsError(msg)
 
 
@@ -177,7 +180,22 @@ def _fail_if_invalid_keyword_arguments(
     if problematic:
         s = "s" if len(problematic) >= 2 else ""  # noqa: PLR2004
         problem_str = ", ".join(list(problematic))
-        msg = f"{funcname}() got unexpected keyword argument{s} {problem_str}"
+        msg = f"{funcname} got unexpected keyword argument{s} {problem_str}"
+        raise InvalidFunctionArgumentsError(msg)
+
+
+def _fail_if_missing_arguments(
+    present_args: set[str],
+    present_kwargs: set[str],
+    required_args: set[str],
+    funcname: str,
+) -> None:
+    provided = present_args | present_kwargs
+    missing = required_args - provided
+    if missing:
+        s = "s" if len(missing) >= 2 else ""  # noqa: PLR2004
+        missing_str = ", ".join(sorted(missing))
+        msg = f"{funcname} is missing required argument{s}: {missing_str}"
         raise InvalidFunctionArgumentsError(msg)
 
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -142,7 +142,7 @@ def test_with_signature_decorator_duplicated_arguments() -> None:
 
     with pytest.raises(
         InvalidFunctionArgumentsError,
-        match=r"f\(\) got multiple values for argument b",
+        match=r"f got multiple values for argument b",
     ):
         f(1, 2, b=3)
 
@@ -154,7 +154,7 @@ def test_with_signature_decorator_invalid_keyword_arguments() -> None:
 
     with pytest.raises(
         InvalidFunctionArgumentsError,
-        match=r"f\(\) got unexpected keyword argument d",
+        match=r"f got unexpected keyword argument d",
     ):
         f(1, 2, d=4)
 
@@ -205,6 +205,30 @@ def test_rename_arguments_direct_call_annotated() -> None:
         "c": "bool",
         "return": "float",
     }
+
+
+def test_with_signature_decorator_missing_arguments() -> None:
+    @with_signature(args=["a", "b"], kwargs=["c"])
+    def f(*args, **kwargs):
+        return sum(args) + sum(kwargs.values())
+
+    with pytest.raises(
+        InvalidFunctionArgumentsError,
+        match="missing required argument",
+    ):
+        f(1)
+
+
+def test_with_signature_decorator_missing_all_arguments() -> None:
+    @with_signature(args=["a", "b"], kwargs=["c"])
+    def f(*args, **kwargs):
+        return sum(args) + sum(kwargs.values())
+
+    with pytest.raises(
+        InvalidFunctionArgumentsError,
+        match=r"missing required arguments.*a.*b",
+    ):
+        f()
 
 
 def test_with_signature_invalid_args_type() -> None:


### PR DESCRIPTION
Set `__name__` on the inner function so signature enforcement produces:

> `The concatenated function is missing ...`

instead of 

> `concatenated() missing ...`

Drop "()" from all _fail_if_* format strings and add "is" before "missing".


*Note:* Since the same error message is used by `with_signature`, we can't just change the error message itself.