### PR TITLE
Streamline API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [conda-forge](https://anaconda.org/conda-forge/dags).
 
 ## 0.5.0
 
+- :gh:`75` Streamline public API (:ghuser:`hmgaudecker`).
+
 - :gh:`65` Update docs and use Jupyter Book for documentation (:ghuser:`hmgaudecker`).
 
 - :gh:`72` Remove type checking blocks (:ghuser:`hmgaudecker`).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ releases are available on [conda-forge](https://anaconda.org/conda-forge/dags).
 
 - :gh:`75` Streamline public API (:ghuser:`hmgaudecker`).
 
+  - Deprecate `one_function_without_tree_logic` and
+    `functions_without_tree_logic` in favour of
+    `get_one_function_without_tree_logic` and
+    `get_functions_without_tree_logic`.
+
 - :gh:`65` Update docs and use Jupyter Book for documentation (:ghuser:`hmgaudecker`).
 
 - :gh:`72` Remove type checking blocks (:ghuser:`hmgaudecker`).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,11 @@ releases are available on [conda-forge](https://anaconda.org/conda-forge/dags).
 
 - :gh:`75` Streamline public API (:ghuser:`hmgaudecker`).
 
-  - Deprecate `one_function_without_tree_logic` and
-    `functions_without_tree_logic` in favour of
-    `get_one_function_without_tree_logic` and
-    `get_functions_without_tree_logic`.
+  - Deprecate `one_function_without_tree_logic`,
+    `functions_without_tree_logic`, and `fail_if_paths_are_invalid`
+    in favor of `get_one_function_without_tree_logic`,
+    `get_functions_without_tree_logic`, and
+    `dags.tree.validation.fail_if_paths_are_invalid`.
 
 - :gh:`65` Update docs and use Jupyter Book for documentation (:ghuser:`hmgaudecker`).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,6 +104,25 @@ Rename function parameters using a mapping dict. Can be used as a decorator or c
 
 ---
 
+### `dags.with_signature`
+
+```python
+with_signature(
+    func: Callable | None = None,
+    *,
+    args: Mapping[str, str] | Sequence[str] | None = None,
+    kwargs: Mapping[str, str] | Sequence[str] | None = None,
+    enforce: bool = True,
+    return_annotation: Any = inspect.Parameter.empty,
+) -> Callable
+```
+
+Add a signature to a function of type `f(*args, **kwargs)`. Can be used as a decorator with or without arguments.
+
+`dags.signature`
+
+---
+
 ## Tree Utilities
 
 All tree symbols are available from `dags.tree`.
@@ -264,10 +283,10 @@ Create a nested input structure template with type annotations based on function
 
 ---
 
-### `dags.tree.functions_without_tree_logic`
+### `dags.tree.get_functions_without_tree_logic`
 
 ```python
-functions_without_tree_logic(
+get_functions_without_tree_logic(
     functions: NestedFunctionDict,
     top_level_namespace: set[str],
 ) -> QNameFunctionDict
@@ -279,10 +298,10 @@ Flatten a nested function dict and rename all parameters to qualified absolute n
 
 ---
 
-### `dags.tree.one_function_without_tree_logic`
+### `dags.tree.get_one_function_without_tree_logic`
 
 ```python
-one_function_without_tree_logic(
+get_one_function_without_tree_logic(
     function: Callable,
     tree_path: tuple[str, ...],
     top_level_namespace: set[str],
@@ -297,7 +316,9 @@ Convert a single function from relative parameter names to qualified absolute na
 
 ## Tree Validation
 
-### `dags.tree.fail_if_paths_are_invalid`
+All validation symbols are available from `dags.tree.validation`.
+
+### `dags.tree.validation.fail_if_paths_are_invalid`
 
 ```python
 fail_if_paths_are_invalid(
@@ -316,7 +337,7 @@ Validate all tree paths for trailing underscores and repeated top-level elements
 
 ---
 
-### `dags.tree.fail_if_path_elements_have_trailing_underscores`
+### `dags.tree.validation.fail_if_path_elements_have_trailing_underscores`
 
 ```python
 fail_if_path_elements_have_trailing_underscores(
@@ -330,7 +351,7 @@ Check that no non-leaf path element ends with an underscore.
 
 ---
 
-### `dags.tree.fail_if_top_level_elements_repeated_in_paths`
+### `dags.tree.validation.fail_if_top_level_elements_repeated_in_paths`
 
 ```python
 fail_if_top_level_elements_repeated_in_paths(
@@ -345,7 +366,7 @@ Fail if any top-level namespace element appears deeper in the hierarchy.
 
 ---
 
-### `dags.tree.fail_if_top_level_elements_repeated_in_single_path`
+### `dags.tree.validation.fail_if_top_level_elements_repeated_in_single_path`
 
 ```python
 fail_if_top_level_elements_repeated_in_single_path(

--- a/docs/tree.ipynb
+++ b/docs/tree.ipynb
@@ -269,35 +269,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### functions_without_tree_logic\n",
-    "\n",
-    "If you want to use the regular `concatenate_functions` but start with nested function dictionaries, this utility flattens the functions and converts their parameter names to qualified names:"
-   ]
+   "source": "### get_functions_without_tree_logic\n\nIf you want to use the regular `concatenate_functions` but start with nested function dictionaries, this utility flattens the functions and converts their parameter names to qualified names:"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def y(x):\n",
-    "    return x + 1\n",
-    "\n",
-    "\n",
-    "tree_functions = {\n",
-    "    \"a\": {\n",
-    "        \"x\": lambda: 1,\n",
-    "        \"y\": y,\n",
-    "    },\n",
-    "}\n",
-    "\n",
-    "flat_functions = dt.functions_without_tree_logic(\n",
-    "    tree_functions, top_level_namespace={\"a\"}\n",
-    ")\n",
-    "\n",
-    "list(flat_functions.keys())"
-   ]
+   "source": "def y(x):\n    return x + 1\n\n\ntree_functions = {\n    \"a\": {\n        \"x\": lambda: 1,\n        \"y\": y,\n    },\n}\n\nflat_functions = dt.get_functions_without_tree_logic(\n    tree_functions, top_level_namespace={\"a\"}\n)\n\nlist(flat_functions.keys())"
   },
   {
    "cell_type": "markdown",
@@ -348,43 +327,19 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### one_function_without_tree_logic\n",
-    "\n",
-    "Convert a single function's parameters from relative names to qualified absolute names.\n",
-    "This is the building block used by `functions_without_tree_logic`:"
-   ]
+   "source": "### get_one_function_without_tree_logic\n\nConvert a single function's parameters from relative names to qualified absolute names.\nThis is the building block used by `get_functions_without_tree_logic`:"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import dags\n",
-    "\n",
-    "\n",
-    "def my_func(wage, capital):\n",
-    "    return wage + capital\n",
-    "\n",
-    "\n",
-    "converted = dt.one_function_without_tree_logic(\n",
-    "    function=my_func,\n",
-    "    tree_path=(\"taxes\", \"income_tax\"),\n",
-    "    top_level_namespace={\"income\", \"taxes\"},\n",
-    ")\n",
-    "\n",
-    "dags.get_free_arguments(converted)"
-   ]
+   "source": "import dags\n\n\ndef my_func(wage, capital):\n    return wage + capital\n\n\nconverted = dt.get_one_function_without_tree_logic(\n    function=my_func,\n    tree_path=(\"taxes\", \"income_tax\"),\n    top_level_namespace={\"income\", \"taxes\"},\n)\n\ndags.get_free_arguments(converted)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Validation Functions\n",
-    "\n",
-    "The tree module includes utilities to catch common mistakes early — before they cause confusing errors downstream."
-   ]
+   "source": "## Validation Functions\n\nThe tree module includes utilities to catch common mistakes early — before they cause confusing errors downstream. These are available from `dags.tree.validation`."
   },
   {
    "cell_type": "markdown",
@@ -402,9 +357,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "dt.fail_if_path_elements_have_trailing_underscores({(\"bad_\", \"name\")})"
-   ]
+   "source": "from dags.tree.validation import (\n    fail_if_path_elements_have_trailing_underscores,\n    fail_if_top_level_elements_repeated_in_paths,\n)\n\nfail_if_path_elements_have_trailing_underscores({(\"bad_\", \"name\")})"
   },
   {
    "cell_type": "markdown",
@@ -422,12 +375,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "dt.fail_if_top_level_elements_repeated_in_paths(\n",
-    "    all_tree_paths={(\"a\", \"b\", \"a\")},\n",
-    "    top_level_namespace={\"a\", \"b\"},\n",
-    ")"
-   ]
+   "source": "fail_if_top_level_elements_repeated_in_paths(\n    all_tree_paths={(\"a\", \"b\", \"a\")},\n    top_level_namespace={\"a\", \"b\"},\n)"
   },
   {
    "cell_type": "markdown",
@@ -488,21 +436,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "flat_regime_functions = dt.functions_without_tree_logic(\n",
-    "    regime_functions,\n",
-    "    top_level_namespace={\"working\", \"retired\", \"wage\", \"hours\", \"pension\", \"leisure\"},\n",
-    ")\n",
-    "\n",
-    "combined = dags.concatenate_functions(\n",
-    "    functions=flat_regime_functions,\n",
-    "    targets=[\"working__utility\", \"retired__utility\"],\n",
-    "    return_type=\"dict\",\n",
-    ")\n",
-    "\n",
-    "result = combined(wage=20, hours=40, pension=1000, leisure=10)\n",
-    "dt.unflatten_from_qnames(result)"
-   ]
+   "source": "flat_regime_functions = dt.get_functions_without_tree_logic(\n    regime_functions,\n    top_level_namespace={\"working\", \"retired\", \"wage\", \"hours\", \"pension\", \"leisure\"},\n)\n\ncombined = dags.concatenate_functions(\n    functions=flat_regime_functions,\n    targets=[\"working__utility\", \"retired__utility\"],\n    return_type=\"dict\",\n)\n\nresult = combined(wage=20, hours=40, pension=1000, leisure=10)\ndt.unflatten_from_qnames(result)"
   },
   {
    "cell_type": "markdown",

--- a/pixi.lock
+++ b/pixi.lock
@@ -5406,8 +5406,8 @@ packages:
   timestamp: 1770674447292
 - pypi: ./
   name: dags
-  version: 0.4.4.dev57+g4b94d8af1.d20260307
-  sha256: f626c70e0a41c512cbce512e889a78c6792f17af3a398fa0a22eaf82c6eaa503
+  version: 0.4.4.dev8+g2550a1f15.d20260309
+  sha256: dd3a91e4b5d5e324ed387d033e9014e33f39c0bab1090e444ae4501e207f1be3
   requires_dist:
   - flatten-dict
   - networkx>=3.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,18 @@ name = "Janoś Gabler"
 email = "janos.gabler@gmail.com"
 [[project.authors]]
 name = "Tobias Raabe"
+[[project.authors]]
+name = "Tim Mensinger"
+email = "mensingertim@gmail.com"
+[[project.authors]]
+name = "Hans-Martin von Gaudecker"
+email = "hmgaudecker@uni-bonn.de"
 [[project.maintainers]]
 name = "Hans-Martin von Gaudecker"
 email = "hmgaudecker@uni-bonn.de"
+[[project.maintainers]]
+name = "Tim Mensinger"
+email = "mensingertim@gmail.com"
 [project.urls]
 Github = "https://github.com/OpenSourceEconomics/dags"
 Repository = "https://github.com/OpenSourceEconomics/dags"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ pydocstyle.convention = "google"
 column_width = 88
 max_supported_python = "3.14"
 table_format = "long"
-collapse_tables = [ "tool.hatch", "tool.pytest", "tool.pytask", "tool.ty" ]
+collapse_tables = [ "tool.hatch", "tool.pytest", "tool.ty" ]
 expand_tables = [
   "tool.pixi.dependencies",
   "tool.pixi.environments",

--- a/src/dags/__init__.py
+++ b/src/dags/__init__.py
@@ -6,29 +6,14 @@ from dags.dag import (
     create_dag,
     get_ancestors,
 )
-from dags.exceptions import (
-    AnnotationMismatchError,
-    CyclicDependencyError,
-    DagsError,
-    InvalidFunctionArgumentsError,
-    MissingFunctionsError,
-    ValidationError,
-)
-from dags.signature import rename_arguments
+from dags.signature import rename_arguments, with_signature
 
 __all__ = [
-    "AnnotationMismatchError",
-    "CyclicDependencyError",
-    "DagsError",
-    "InvalidFunctionArgumentsError",
-    "MissingFunctionsError",
-    "RepeatedTopLevelElementError",
-    "TrailingUnderscoreError",
-    "ValidationError",
     "concatenate_functions",
     "create_dag",
     "get_ancestors",
     "get_annotations",
     "get_free_arguments",
     "rename_arguments",
+    "with_signature",
 ]

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -35,14 +35,33 @@ def one_function_without_tree_logic(
 ) -> Callable[..., Any]:
     """Deprecated: Use get_one_function_without_tree_logic instead."""
     warnings.warn(
-        "'one_function_without_tree_logic' is deprecated, "
-        "update the package calling it to a version released after 15 March 2026.",
-        FutureWarning,
+        message="'one_function_without_tree_logic' is deprecated in favor of "
+        "'get_one_function_without_tree_logic'.\n"
+        "Update the package calling it to a version released after 15 March 2026.",
+        category=FutureWarning,
         stacklevel=2,
     )
     return get_one_function_without_tree_logic(
         function=function,
         tree_path=tree_path,
+        top_level_namespace=top_level_namespace,
+    )
+
+
+def functions_without_tree_logic(
+    functions: NestedFunctionDict,
+    top_level_namespace: set[str],
+) -> QNameFunctionDict:
+    """Deprecated: Use get_functions_without_tree_logic instead."""
+    warnings.warn(
+        message="'functions_without_tree_logic' is deprecated in favor of "
+        "'get_functions_without_tree_logic'.\n"
+        "Update the package calling it to a version released after 15 March 2026.",
+        category=FutureWarning,
+        stacklevel=2,
+    )
+    return get_functions_without_tree_logic(
+        functions=functions,
         top_level_namespace=top_level_namespace,
     )
 
@@ -53,29 +72,13 @@ def fail_if_paths_are_invalid(
 ) -> None:
     """Deprecated: Use dags.tree.validation.fail_if_paths_are_invalid instead."""
     warnings.warn(
-        "'fail_if_paths_are_invalid' is deprecated, "
-        "update the package calling it to a version released after 15 March 2026.",
-        FutureWarning,
+        message="Calling 'fail_if_paths_are_invalid' from the dags.tree namespace "
+        "directly is deprecated.\n"
+        "Update the package calling it to a version released after 15 March 2026.",
+        category=FutureWarning,
         stacklevel=2,
     )
     _fail_if_paths_are_invalid(*args, **kwargs)
-
-
-def functions_without_tree_logic(
-    functions: NestedFunctionDict,
-    top_level_namespace: set[str],
-) -> QNameFunctionDict:
-    """Deprecated: Use get_functions_without_tree_logic instead."""
-    warnings.warn(
-        "'functions_without_tree_logic' is deprecated, "
-        "update the package calling it to a version released after 15 March 2026.",
-        FutureWarning,
-        stacklevel=2,
-    )
-    return get_functions_without_tree_logic(
-        functions=functions,
-        top_level_namespace=top_level_namespace,
-    )
 
 
 __all__ = [

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -23,6 +23,9 @@ from dags.tree.tree_utils import (
     unflatten_from_tree_paths,
 )
 from dags.tree.typing import NestedFunctionDict, QNameFunctionDict
+from dags.tree.validation import (
+    fail_if_paths_are_invalid as _fail_if_paths_are_invalid,
+)
 
 
 def one_function_without_tree_logic(
@@ -42,6 +45,20 @@ def one_function_without_tree_logic(
         tree_path=tree_path,
         top_level_namespace=top_level_namespace,
     )
+
+
+def fail_if_paths_are_invalid(
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """Deprecated: Use dags.tree.validation.fail_if_paths_are_invalid instead."""
+    warnings.warn(
+        "'fail_if_paths_are_invalid' is deprecated, "
+        "update the package calling it to a version released after 15 March 2026.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    _fail_if_paths_are_invalid(*args, **kwargs)
 
 
 def functions_without_tree_logic(
@@ -69,6 +86,7 @@ __all__ = [
     "get_functions_without_tree_logic",
     "get_one_function_without_tree_logic",
     # Deprecated
+    "fail_if_paths_are_invalid",
     "functions_without_tree_logic",
     "one_function_without_tree_logic",
     # Qualified name utilities

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -4,12 +4,8 @@ from dags.tree.dag_tree import (
     concatenate_functions_tree,
     create_dag_tree,
     create_tree_with_input_types,
-    functions_without_tree_logic,
-    one_function_without_tree_logic,
-)
-from dags.tree.exceptions import (
-    RepeatedTopLevelElementError,
-    TrailingUnderscoreError,
+    get_functions_without_tree_logic,
+    get_one_function_without_tree_logic,
 )
 from dags.tree.tree_utils import (
     QNAME_DELIMITER,
@@ -22,28 +18,14 @@ from dags.tree.tree_utils import (
     unflatten_from_qnames,
     unflatten_from_tree_paths,
 )
-from dags.tree.validation import (
-    fail_if_path_elements_have_trailing_underscores,
-    fail_if_paths_are_invalid,
-    fail_if_top_level_elements_repeated_in_paths,
-    fail_if_top_level_elements_repeated_in_single_path,
-)
 
 __all__ = [
     # Primary functions
     "create_tree_with_input_types",
     "create_dag_tree",
     "concatenate_functions_tree",
-    "functions_without_tree_logic",
-    "one_function_without_tree_logic",
-    # Validation functions
-    "fail_if_paths_are_invalid",
-    "fail_if_path_elements_have_trailing_underscores",
-    "fail_if_top_level_elements_repeated_in_paths",
-    "fail_if_top_level_elements_repeated_in_single_path",
-    # Exceptions
-    "RepeatedTopLevelElementError",
-    "TrailingUnderscoreError",
+    "get_functions_without_tree_logic",
+    "get_one_function_without_tree_logic",
     # Qualified name utilities
     "QNAME_DELIMITER",
     "flatten_to_qnames",

--- a/src/dags/tree/__init__.py
+++ b/src/dags/tree/__init__.py
@@ -1,5 +1,9 @@
 """Module for handling DAG trees with nested dictionaries and qualified names."""
 
+import warnings
+from collections.abc import Callable
+from typing import Any
+
 from dags.tree.dag_tree import (
     concatenate_functions_tree,
     create_dag_tree,
@@ -18,6 +22,44 @@ from dags.tree.tree_utils import (
     unflatten_from_qnames,
     unflatten_from_tree_paths,
 )
+from dags.tree.typing import NestedFunctionDict, QNameFunctionDict
+
+
+def one_function_without_tree_logic(
+    function: Callable[..., Any],
+    tree_path: tuple[str, ...],
+    top_level_namespace: set[str],
+) -> Callable[..., Any]:
+    """Deprecated: Use get_one_function_without_tree_logic instead."""
+    warnings.warn(
+        "'one_function_without_tree_logic' is deprecated, "
+        "update the package calling it to a version released after 15 March 2026.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return get_one_function_without_tree_logic(
+        function=function,
+        tree_path=tree_path,
+        top_level_namespace=top_level_namespace,
+    )
+
+
+def functions_without_tree_logic(
+    functions: NestedFunctionDict,
+    top_level_namespace: set[str],
+) -> QNameFunctionDict:
+    """Deprecated: Use get_functions_without_tree_logic instead."""
+    warnings.warn(
+        "'functions_without_tree_logic' is deprecated, "
+        "update the package calling it to a version released after 15 March 2026.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    return get_functions_without_tree_logic(
+        functions=functions,
+        top_level_namespace=top_level_namespace,
+    )
+
 
 __all__ = [
     # Primary functions
@@ -26,6 +68,9 @@ __all__ = [
     "concatenate_functions_tree",
     "get_functions_without_tree_logic",
     "get_one_function_without_tree_logic",
+    # Deprecated
+    "functions_without_tree_logic",
+    "one_function_without_tree_logic",
     # Qualified name utilities
     "QNAME_DELIMITER",
     "flatten_to_qnames",

--- a/src/dags/tree/dag_tree.py
+++ b/src/dags/tree/dag_tree.py
@@ -57,7 +57,7 @@ def create_tree_with_input_types(
         functions=functions,
         top_level_inputs=set(top_level_inputs),
     )
-    functions_for_flat_dags = functions_without_tree_logic(
+    functions_for_flat_dags = get_functions_without_tree_logic(
         functions=functions,
         top_level_namespace=top_level_namespace,
     )
@@ -109,7 +109,7 @@ def create_dag_tree(
         functions=functions,
         inputs=inputs,
     )
-    functions_for_flat_dags = functions_without_tree_logic(
+    functions_for_flat_dags = get_functions_without_tree_logic(
         functions=functions,
         top_level_namespace=top_level_namespace,
     )
@@ -141,7 +141,7 @@ def concatenate_functions_tree(
         functions=functions,
         inputs=inputs,
     )
-    functions_for_flat_dags = functions_without_tree_logic(
+    functions_for_flat_dags = get_functions_without_tree_logic(
         functions=functions,
         top_level_namespace=top_level_namespace,
     )
@@ -162,7 +162,7 @@ def concatenate_functions_tree(
     return wrapper
 
 
-def functions_without_tree_logic(
+def get_functions_without_tree_logic(
     functions: NestedFunctionDict,
     top_level_namespace: set[str],
 ) -> QNameFunctionDict:
@@ -192,7 +192,7 @@ def functions_without_tree_logic(
 
     qname_functions = {}
     for path, func in tree_path_functions.items():
-        renamed = one_function_without_tree_logic(
+        renamed = get_one_function_without_tree_logic(
             function=func,
             tree_path=path,
             top_level_namespace=top_level_namespace,
@@ -202,7 +202,7 @@ def functions_without_tree_logic(
     return qname_functions
 
 
-def one_function_without_tree_logic(
+def get_one_function_without_tree_logic(
     function: Callable[..., Any],
     tree_path: tuple[str, ...],
     top_level_namespace: set[str],

--- a/src/dags/tree/validation.py
+++ b/src/dags/tree/validation.py
@@ -37,7 +37,7 @@ def fail_if_paths_are_invalid(  # noqa: PLR0913
 
     Note: Sometimes you want to pass both `functions` (the nested function dict you will
     start out with) and `abs_qnames_functions` (the result of running
-    `functions_without_tree_logic` on `functions`, which contains the converted
+    `get_functions_without_tree_logic` on `functions`, which contains the converted
     parameters of functions, too). Even though the former may be seen as a subset of the
     latter, the conversion to qualified absolute names is not innocuous when it comes to
     the check for trailing underscores. The reason is that the conversion from qualified
@@ -48,7 +48,7 @@ def fail_if_paths_are_invalid(  # noqa: PLR0913
         functions:
             The nested function dict.
         abs_qnames_functions:
-            The result of running `functions_without_tree_logic` on `functions`.
+            The result of running `get_functions_without_tree_logic` on `functions`.
         data_tree:
             The tree of input data (typically not used together with `input_structure`).
         input_structure:

--- a/tests/test_dag_tree/test_create_input_structure.py
+++ b/tests/test_dag_tree/test_create_input_structure.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import pytest
 
-from dags.tree import RepeatedTopLevelElementError, create_tree_with_input_types
+from dags.tree import create_tree_with_input_types
+from dags.tree.exceptions import RepeatedTopLevelElementError
 from dags.tree.typing import (
     NestedFunctionDict,
     NestedInputStructureDict,

--- a/tests/test_dag_tree/test_deprecations.py
+++ b/tests/test_dag_tree/test_deprecations.py
@@ -1,0 +1,44 @@
+"""Tests for deprecated shims in dags.tree."""
+
+import pytest
+
+from dags.tree import (
+    fail_if_paths_are_invalid,
+    functions_without_tree_logic,
+    one_function_without_tree_logic,
+)
+from dags.tree.typing import NestedFunctionDict
+
+
+def f(a: int) -> int:
+    return a**2
+
+
+def g(f: int) -> int:
+    return f + 1
+
+
+FUNCTIONS: NestedFunctionDict = {"ns": {"f": f, "g": g}}
+TOP_LEVEL_NAMESPACE: set[str] = {"ns"}
+
+
+def test_one_function_without_tree_logic_emits_warning() -> None:
+    with pytest.warns(FutureWarning, match="one_function_without_tree_logic"):
+        one_function_without_tree_logic(
+            function=f,
+            tree_path=("ns", "f"),
+            top_level_namespace=TOP_LEVEL_NAMESPACE,
+        )
+
+
+def test_functions_without_tree_logic_emits_warning() -> None:
+    with pytest.warns(FutureWarning, match="functions_without_tree_logic"):
+        functions_without_tree_logic(
+            functions=FUNCTIONS,
+            top_level_namespace=TOP_LEVEL_NAMESPACE,
+        )
+
+
+def test_fail_if_paths_are_invalid_emits_warning() -> None:
+    with pytest.warns(FutureWarning, match="fail_if_paths_are_invalid"):
+        fail_if_paths_are_invalid(functions=FUNCTIONS)

--- a/tests/test_dag_tree/test_parameters.py
+++ b/tests/test_dag_tree/test_parameters.py
@@ -10,7 +10,7 @@ from dags.tree.dag_tree import (
     _get_top_level_namespace_final,
     _get_top_level_namespace_initial,
     _map_parameters_rel_to_abs,
-    functions_without_tree_logic,
+    get_functions_without_tree_logic,
 )
 from dags.tree.typing import (
     Callable,
@@ -191,7 +191,7 @@ def test_correct_argument_names(
         functions=functions,
         inputs=input_structure,
     )
-    qname_functions = functions_without_tree_logic(
+    qname_functions = get_functions_without_tree_logic(
         functions=functions,
         top_level_namespace=top_level_namespace,
     )


### PR DESCRIPTION
- The main `dags` namespace and that of `dags.tree` were a bit cluttered. This PR removes exceptions and fail-if functions.
- Add Tim and HM to package authors

## Breaking API changes

### Exceptions removed from `dags.__all__`

Import from `dags.exceptions` or `dags.tree.exceptions` instead.

| exception                    | new import path         |
|------------------------------|-------------------------|
| AnnotationMismatchError      | dags.exceptions         |
| CyclicDependencyError        | dags.exceptions         |
| DagsError                    | dags.exceptions         |
| InvalidFunctionArgumentsError| dags.exceptions         |
| MissingFunctionsError        | dags.exceptions         |
| ValidationError              | dags.exceptions         |
| RepeatedTopLevelElementError | dags.tree.exceptions    |
| TrailingUnderscoreError      | dags.tree.exceptions    |

### `with_signature` added to `dags.__all__`

```python
# before
from dags.signature import with_signature

# after (both work)
from dags import with_signature
from dags.signature import with_signature
```

### Validation functions removed from `dags.tree.__all__`

Import from `dags.tree.validation` instead.

```python
# before
from dags.tree import fail_if_paths_are_invalid

# after
from dags.tree.validation import fail_if_paths_are_invalid
```

Applies to: `fail_if_paths_are_invalid`, `fail_if_path_elements_have_trailing_underscores`, `fail_if_top_level_elements_repeated_in_paths`, `fail_if_top_level_elements_repeated_in_single_path`.

### Renamed functions in `dags.tree`

| before                          | after                               |
|---------------------------------|-------------------------------------|
| functions_without_tree_logic    | get_functions_without_tree_logic    |
| one_function_without_tree_logic | get_one_function_without_tree_logic |

```python
# before
dt.functions_without_tree_logic(...)
dt.one_function_without_tree_logic(...)

# after
dt.get_functions_without_tree_logic(...)
dt.get_one_function_without_tree_logic(...)
```